### PR TITLE
Schema fixes

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -25,9 +25,14 @@ CREATE TABLE contactgroup_member (
     PRIMARY KEY (contactgroup_id, contact_id)
 );
 
+CREATE TABLE schedule (
+    id bigserial PRIMARY KEY,
+    name text NOT NULL
+);
+
 CREATE TABLE timeperiod (
     id bigserial PRIMARY KEY,
-    owned_by_schedule_id bigint REFERENCES timeperiod(id) -- nullable for future standalone timeperiods
+    owned_by_schedule_id bigint REFERENCES schedule(id) -- nullable for future standalone timeperiods
 );
 
 CREATE TABLE timeperiod_entry (
@@ -38,11 +43,6 @@ CREATE TABLE timeperiod_entry (
     timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
     rrule text, -- recurrence rule (RFC5545)
     description text
-);
-
-CREATE TABLE schedule (
-    id bigserial PRIMARY KEY,
-    name text NOT NULL
 );
 
 CREATE TABLE schedule_member (

--- a/schema/pgsql/upgrades/003.sql
+++ b/schema/pgsql/upgrades/003.sql
@@ -1,1 +1,3 @@
 ALTER TABLE contact_address ALTER COLUMN contact_id SET NOT NULL;
+ALTER TABLE timeperiod DROP CONSTRAINT timeperiod_owned_by_schedule_id_fkey;
+ALTER TABLE timeperiod ADD CONSTRAINT timeperiod_owned_by_schedule_id_fkey FOREIGN KEY (owned_by_schedule_id) REFERENCES schedule(id);


### PR DESCRIPTION
- add NOT NULL constraint to `contact_address.contact_id`, it was missing
- fix `timeperiod.owned_by_schedule_id` foreign key constraint, it referenced the wrong table (moves the `CREATE TABLE schedule` so that the reference can still be created inside `CREATE TABLE timeperiod`)