### PR TITLE
Fix shadowing of database column names in Rule struct

### DIFF
--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -1,7 +1,6 @@
 package rule
 
 import (
-	"database/sql"
 	"github.com/icinga/icingadb/pkg/types"
 	"github.com/icinga/noma/internal/object"
 	"github.com/icinga/noma/internal/timeperiod"
@@ -12,7 +11,7 @@ type Rule struct {
 	IsActive         types.Bool `db:"is_active"`
 	Name             string     `db:"name"`
 	TimePeriod       *timeperiod.TimePeriod
-	TimePeriodID     sql.NullInt64  `db:"timeperiod_id"`
+	TimePeriodID     types.Int      `db:"timeperiod_id"`
 	ObjectFilter     *object.Filter `db:"-"`
 	ObjectFilterExpr types.String   `db:"object_filter"`
 	Escalations      []*Escalation


### PR DESCRIPTION
`Rule#ObjectFilter` is of type `*object.Filter` and doesn't have any
defined tags and is set its field name to `object_filter` by default.
`Rule#ObjectFilterExpr` on ther other hand defines a tag that is named
the same as the first one (`object_filter`) and thus the second field
isn't taken into account in `DB#BuildColumns()` since it's a duplicate
of the first field, which results in `Rule#ObjectFilter` not being loaded
from the database at all.