### PR TITLE
Don't use the same event time for all incident histories

### DIFF
--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -107,7 +107,7 @@ func (i *Incident) AddEvent(db *icingadb.DB, ev *event.Event) error {
 
 // AddRecipient adds recipient from the given *rule.Escalation to this incident.
 // Syncs also all the recipients with the database and returns an error on db failure.
-func (i *Incident) AddRecipient(escalation *rule.Escalation, t time.Time, eventId int64) error {
+func (i *Incident) AddRecipient(escalation *rule.Escalation, eventId int64) error {
 	newRole := RoleRecipient
 	if i.HasManager() {
 		newRole = RoleSubscriber
@@ -134,7 +134,7 @@ func (i *Incident) AddRecipient(escalation *rule.Escalation, t time.Time, eventI
 					IncidentID:       i.incidentRowID,
 					EventID:          utils.ToDBInt(eventId),
 					Key:              cr.Key,
-					Time:             types.UnixMilli(t),
+					Time:             types.UnixMilli(time.Now()),
 					Type:             RecipientRoleChanged,
 					NewRecipientRole: newRole,
 					OldRecipientRole: oldRole,

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -216,7 +216,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 		hr := &incident.HistoryRow{
 			EventID:     utils.ToDBInt(ev.ID),
 			Type:        incident.SourceSeverityChanged,
-			Time:        types.UnixMilli(ev.Time),
+			Time:        types.UnixMilli(time.Now()),
 			NewSeverity: ev.Severity,
 			OldSeverity: oldSourceSeverity,
 			Message:     utils.ToDBString(ev.Message),
@@ -262,7 +262,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 
 		hr := &incident.HistoryRow{
 			EventID:                   utils.ToDBInt(ev.ID),
-			Time:                      types.UnixMilli(ev.Time),
+			Time:                      types.UnixMilli(time.Now()),
 			Type:                      incident.SeverityChanged,
 			NewSeverity:               newIncidentSeverity,
 			OldSeverity:               oldIncidentSeverity,
@@ -279,12 +279,12 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if newIncidentSeverity == event.SeverityOK {
-		currentIncident.RecoveredAt = ev.Time
+		currentIncident.RecoveredAt = time.Now()
 		l.logger.Infof("[%s %s] all sources recovered, closing incident", obj.DisplayName(), currentIncident.String())
 
 		hr := &incident.HistoryRow{
 			EventID: utils.ToDBInt(ev.ID),
-			Time:    types.UnixMilli(ev.Time),
+			Time:    types.UnixMilli(time.Now()),
 			Type:    incident.Closed,
 		}
 		err = incident.RemoveCurrent(obj, hr)
@@ -330,7 +330,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 			l.logger.Infof("[%s %s] rule %q matches", obj.DisplayName(), currentIncident.String(), r.Name)
 
 			history := &incident.HistoryRow{
-				Time:                      types.UnixMilli(ev.Time),
+				Time:                      types.UnixMilli(time.Now()),
 				EventID:                   utils.ToDBInt(ev.ID),
 				RuleID:                    utils.ToDBInt(r.ID),
 				Type:                      incident.RuleMatched,
@@ -406,7 +406,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 			}
 
 			state.RuleEscalationID = escalationID
-			state.TriggeredAt = types.UnixMilli(ev.Time)
+			state.TriggeredAt = types.UnixMilli(time.Now())
 
 			r := l.runtimeConfig.Rules[escalation.RuleID]
 			l.logger.Infof("[%s %s] rule %q reached escalation %q", obj.DisplayName(), currentIncident.String(), r.Name, escalation.DisplayName())
@@ -428,7 +428,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 
-			err = currentIncident.AddRecipient(escalation, ev.Time, ev.ID)
+			err = currentIncident.AddRecipient(escalation, ev.ID)
 			if err != nil {
 				_, _ = fmt.Fprintln(w, err)
 
@@ -482,7 +482,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {
 			hr := &incident.HistoryRow{
 				Key:                       recipient.ToKey(contact),
 				EventID:                   utils.ToDBInt(ev.ID),
-				Time:                      types.UnixMilli(ev.Time),
+				Time:                      types.UnixMilli(time.Now()),
 				Type:                      incident.Notified,
 				ChannelType:               utils.ToDBString(chType),
 				CausedByIncidentHistoryID: causedByIncidentHistoryId,
@@ -614,7 +614,7 @@ func (l *Listener) ProcessAcknowledgementEvent(i *incident.Incident, ev event.Ev
 		Key:              recipientKey,
 		EventID:          utils.ToDBInt(ev.ID),
 		Type:             incident.RecipientRoleChanged,
-		Time:             types.UnixMilli(ev.Time),
+		Time:             types.UnixMilli(time.Now()),
 		NewRecipientRole: newRole,
 		OldRecipientRole: oldRole,
 		Message:          utils.ToDBString(ev.Message),


### PR DESCRIPTION
If all the incident history entries share the same event time, noma-web won't be able to display them in the correct chronological order.