### PR TITLE
icinga2.conf: urlencode service and host names

### DIFF
--- a/icinga2.conf
+++ b/icinga2.conf
@@ -9,6 +9,35 @@ if (!globals.contains("IcingaNotificationsEventSourceId")) {
 	const IcingaNotificationsEventSourceId = 1
 }
 
+// urlencode a string loosely based on RFC 3986.
+//
+// Char replacement will be performed through a simple lookup table based on
+// the RFC's chapters 2.2 and 2.3. This, however, is limited to ASCII.
+function urlencode(str) {
+	var replacement = {
+		// gen-delims
+		":" = "%3A", "/" = "%2F", "?" = "%3F", "#" = "%23", "[" = "%5B", "]" = "%5D", "@" = "%40"
+
+		// sub-delims
+		"!" = "%21", "$" = "%24", "&" = "%26", "'" = "%27", "(" = "%28", ")" = "%29"
+		"*" = "%2A", "+" = "%2B", "," = "%2C", ";" = "%3B", "=" = "%3D"
+
+		// additionals based on !unreserved
+		"\n" = "%0A", "\r" = "%0D", " " = "%20", "\"" = "%22"
+	}
+
+	var pos = 0
+	var out = ""
+
+	while (pos < str.len()) {
+		var cur = str.substr(pos, 1)
+		out += replacement.contains(cur) ? replacement.get(cur) : cur
+		pos += 1
+	}
+
+	return out
+}
+
 object User "icinga-notifications" {
 	# Workaround, types filter here must exclude Problem, otherwise no Acknowledgement notifications are sent.
 	# https://github.com/Icinga/icinga2/issues/9739
@@ -42,7 +71,7 @@ var hostBody = baseBody + {
 		args.name = macro("$event_object_name$")
 		args.username = macro("$event_author$")
 		args.message = macro("$event_message$")
-		args.url = macro("$event_action_url$")
+		args.url = IcingaNotificationsIcingaWebUrl + "/icingadb/host?name=" + urlencode(macro("$host.name$"))
 		args.source_id = macro("$event_source_id$")
 
 		var type = macro("$event_type$")
@@ -83,7 +112,6 @@ object NotificationCommand "icinga-notifications-host" use(hostBody, hostExtraTa
 		event_author = "$notification.author$"
 		event_message = "$notification.comment$"
 		event_object_name = "$host.display_name$"
-		event_action_url = IcingaNotificationsIcingaWebUrl + "/icingadb/host?name=$host.name$"
 		event_extra_tags = hostExtraTags
 		event_source_id = IcingaNotificationsEventSourceId
 	}
@@ -115,7 +143,6 @@ object EventCommand "icinga-notifications-host-events" use(hostBody, hostExtraTa
 		event_author = ""
 		event_message = "$host.output$"
 		event_object_name = "$host.display_name$"
-		event_action_url = IcingaNotificationsIcingaWebUrl + "/icingadb/host?name=$host.name$"
 		event_extra_tags = hostExtraTags
 		event_source_id = IcingaNotificationsEventSourceId
 	}
@@ -151,7 +178,7 @@ var serviceBody = baseBody + {
 		args.name = macro("$event_object_name$")
 		args.username = macro("$event_author$")
 		args.message = macro("$event_message$")
-		args.url = macro("$event_action_url$")
+		args.url = IcingaNotificationsIcingaWebUrl + "/icingadb/service?name=" + urlencode(macro("$service.name$")) + "&host.name=" + urlencode(macro("$service.host.name$"))
 		args.source_id = macro("$event_source_id$")
 
 		var type = macro("$event_type$")
@@ -197,7 +224,6 @@ object NotificationCommand "icinga-notifications-service" use(serviceBody, servi
 		event_author = "$notification.author$"
 		event_message = "$notification.comment$"
 		event_object_name = "$host.display_name$: $service.display_name$"
-		event_action_url = IcingaNotificationsIcingaWebUrl + "/icingadb/service?name=$service.name$&host.name=$service.host.name$"
 		event_extra_tags = serviceExtraTags
 		event_source_id = IcingaNotificationsEventSourceId
 	}
@@ -239,7 +265,6 @@ object EventCommand "icinga-notifications-service-events" use(serviceBody, servi
 		event_author = ""
 		event_message = "$service.output$"
 		event_object_name = "$host.display_name$: $service.display_name$"
-		event_action_url = IcingaNotificationsIcingaWebUrl + "/icingadb/service?name=$service.name$&host.name=$service.host.name$"
 		event_extra_tags = serviceExtraTags
 		event_source_id = IcingaNotificationsEventSourceId
 	}


### PR DESCRIPTION
Similar to the mail notifications in Icinga 2 itself[^0], both the service name and the host name should be urlencoded. Otherwise, as some checks in my demo setup has shown me, the generated URL are invalid.

- Before: …/icingaweb2/icingadb/service?name=random fortune&host.name=foo
- Afterwards: …/icingaweb2/icingadb/service?name=random%20fortune&host.name=foo

Due to limitations of the Icinga 2 language and its libraries, no generic conversation of a char/rune to its char point value was possible. For this reason a (limited) lookup table based on RFC 3986 was chosen. This works until someone starts using Unicode for their names.

[^0]: https://github.com/Icinga/icinga2/blob/v2.14.0/etc/icinga2/scripts/mail-service-notification.sh#L165