### PR TITLE
GitHub Actions: remove duplicate job names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
   pull_request: {}
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
   pull_request: {}
 
 jobs:
-  build:
+  go:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub branch protection rules can specify that checks are required to succeed, however those are matched by the job name and it's not possible to distinguish by the workflow name. This commit makes the job use distinct names so both can be required individually.