### PR TITLE
golangci-lint: add as a CI and fix raised concerns

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request: {}
 
+permissions:
+  # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents
+  contents: read
+
 jobs:
   go:
     runs-on: ubuntu-latest
@@ -17,3 +21,10 @@ jobs:
       run: go test -v ./...
     - name: Vet
       run: go vet ./...
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        # Enable the gosec linter w/o having to create a .golangci.yml config
+        args: -E gosec
+        only-new-issues: true

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -321,7 +321,7 @@ func (i *Incident) evaluateEscalations(ctx context.Context, tx *sqlx.Tx, ev *eve
 					matched = true
 				} else {
 					cond := &rule.EscalationFilter{
-						IncidentAge:      time.Now().Sub(i.StartedAt),
+						IncidentAge:      time.Since(i.StartedAt),
 						IncidentSeverity: i.Severity,
 					}
 
@@ -416,7 +416,7 @@ func (i *Incident) notifyContact(contact *recipient.Contact, ev *event.Event, ch
 	if ch == nil {
 		i.logger.Errorw("Could not find config for channel", zap.Int64("channel_id", chID))
 
-		return errors.New(fmt.Sprintf("could not find config for channel ID: %d", chID))
+		return fmt.Errorf("could not find config for channel ID: %d", chID)
 	}
 
 	chType := ch.Type

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -48,7 +48,14 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 func (l *Listener) Run() error {
 	l.logger.Infof("Starting listener on http://%s", l.configFile.Listen)
-	return http.ListenAndServe(l.configFile.Listen, l)
+	server := &http.Server{
+		Addr:         l.configFile.Listen,
+		Handler:      l,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+	return server.ListenAndServe()
 }
 
 func (l *Listener) ProcessEvent(w http.ResponseWriter, req *http.Request) {

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -33,8 +33,6 @@ type Object struct {
 	ExtraTags map[string]string
 
 	db *icingadb.DB
-
-	mu sync.Mutex
 }
 
 func NewObject(db *icingadb.DB, ev *event.Event) *Object {
@@ -229,11 +227,7 @@ func (o *Object) EvalExists(key string) bool {
 	}
 
 	_, ok = o.ExtraTags[key]
-	if ok {
-		return true
-	}
-
-	return false
+	return ok
 }
 
 // TODO: the return value of this function must be stable like forever


### PR DESCRIPTION
Implement the well known meta linter golangci-lint in the CI to check for common errors, also in Pull Requests.

This commit also fixes existing issues raised by golangci-lint: simplifications, cleaning up an unused private struct field, and setting an http.Server's timeouts, which are indefinite by default.