### PR TITLE
Shutdown Context and Fixes

### DIFF
--- a/cmd/icinga-notifications-daemon/main.go
+++ b/cmd/icinga-notifications-daemon/main.go
@@ -85,7 +85,9 @@ func main() {
 
 	go runtimeConfig.PeriodicUpdates(ctx, 1*time.Second)
 
-	if err := listener.NewListener(db, conf, runtimeConfig, logs).Run(); err != nil {
-		panic(err)
+	if err := listener.NewListener(db, conf, runtimeConfig, logs).Run(ctx); err != nil {
+		logger.Errorw("Listener has finished with an error", zap.Error(err))
+	} else {
+		logger.Info("Listener has finished")
 	}
 }

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -75,7 +75,7 @@ func (r *RuntimeConfig) PeriodicUpdates(ctx context.Context, interval time.Durat
 				r.logger.Errorw("periodic config update failed, continuing with previous config", zap.Error(err))
 			}
 		case <-ctx.Done():
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR works on the initial signal-based context changes from #112. During testing I found my Icinga Notifications container always being stuck when being shut downed until it got SIGKILLed. Thus, next to the introduction of the signal context, a context bug in the `RuntimeConfig` was fixed and a simple context wrapper was added to the `Listener`.

- __listener: context for Listener.Run__
  Allow gracefully stopping the internal web server when the parent context is closed.
- __runtime: fix RuntimeConfig.PeriodicUpdates context__
  The break only broke out of the select, but continued to for loop.
- __icinga-notifications-daemon: handle SIGINT/SIGTERM__
  Switch to a signal based context which is being canceled for SIGINT and SIGTERM. This change was extracted from the ongoing PR #112.