### PR TITLE
golangci-lint: disable only-new-issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,5 +29,4 @@ jobs:
         version: latest
         # Enable the gosec linter w/o having to create a .golangci.yml config
         args: -E gosec
-        only-new-issues: true
         skip-cache: true


### PR DESCRIPTION
`only-new-issues` seems to hide some issues in PRs even if they are introduced there.  For example, removing all usages of a struct field without touching the field itself is not detected. This can result in CI failures after merging, see #108 and 6f4b437eaa2f6f42ec56f9cfdd715ace071be04d for example.