### PR TITLE
Introduce table for session management

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TYPE boolenum AS ENUM ( 'n', 'y' );
 CREATE TYPE incident_history_event_type AS ENUM (
     -- Order to be honored for events with identical microsecond timestamps.
@@ -318,20 +320,13 @@ CREATE TABLE incident_history (
 CREATE INDEX idx_incident_history_time_type ON incident_history(time, type);
 COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by time/type';
 
-CREATE EXTENSION IF NOT EXISTS citext;
+CREATE TABLE browser_session (
+    php_session_id varchar(256) NOT NULL,
+    username citext NOT NULL,
+    user_agent text NOT NULL,
+    authenticated_at bigint NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
 
-CREATE TABLE browser_session
-(
-    php_session_id   VARCHAR(256) NOT NULL,
-    username         CITEXT       NOT NULL,
-    user_agent       TEXT         NOT NULL,
-    authenticated_at bigint       NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
-
-    CONSTRAINT pk_session PRIMARY KEY (php_session_id, username, user_agent)
+    CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id, username, user_agent)
 );
 
-CREATE INDEX browser_session_authenticated_at_idx
-    ON browser_session (
-        authenticated_at
-    )
-;
+CREATE INDEX browser_session_authenticated_at_idx ON browser_session (authenticated_at);

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -317,3 +317,21 @@ CREATE TABLE incident_history (
 
 CREATE INDEX idx_incident_history_time_type ON incident_history(time, type);
 COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by time/type';
+
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE TABLE browser_session
+(
+    php_session_id   VARCHAR(256) NOT NULL,
+    username         CITEXT       NOT NULL,
+    user_agent       TEXT         NOT NULL,
+    authenticated_at bigint       NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
+
+    CONSTRAINT pk_session PRIMARY KEY (php_session_id, username, user_agent)
+);
+
+CREATE INDEX browser_session_authenticated_at_idx
+    ON browser_session (
+        authenticated_at
+    )
+;

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -1,0 +1,17 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE TABLE browser_session
+(
+    php_session_id   VARCHAR(256) NOT NULL,
+    username         CITEXT       NOT NULL,
+    user_agent       TEXT         NOT NULL,
+    authenticated_at bigint       NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
+
+    CONSTRAINT pk_session PRIMARY KEY (php_session_id, username, user_agent)
+);
+
+CREATE INDEX browser_session_authenticated_at_idx
+    ON browser_session (
+        authenticated_at
+    )
+;

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -1,17 +1,12 @@
 CREATE EXTENSION IF NOT EXISTS citext;
 
-CREATE TABLE browser_session
-(
-    php_session_id   VARCHAR(256) NOT NULL,
-    username         CITEXT       NOT NULL,
-    user_agent       TEXT         NOT NULL,
-    authenticated_at bigint       NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
+CREATE TABLE browser_session (
+    php_session_id varchar(256) NOT NULL,
+    username citext NOT NULL,
+    user_agent text NOT NULL,
+    authenticated_at bigint NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
 
-    CONSTRAINT pk_session PRIMARY KEY (php_session_id, username, user_agent)
+    CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id, username, user_agent)
 );
 
-CREATE INDEX browser_session_authenticated_at_idx
-    ON browser_session (
-        authenticated_at
-    )
-;
+CREATE INDEX browser_session_authenticated_at_idx ON browser_session (authenticated_at);


### PR DESCRIPTION
This feature introduces a new session table which is needed by the `icinga-notifications-web` project.
It stores the current authenticated sessions into the table which allows the background daemon (php-based) to validate a connection and its corresponding browser to an authenticated session.

Read #118 for more information about this addition.