### PR TITLE
GitHub Actions: Check Go Dependency Licenses

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,34 @@
+name: Compliance
+
+on:
+  push:
+    branches: [ main ]
+  pull_request: {}
+
+permissions:
+  # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents
+  contents: read
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: Download modules to local cache
+      run: go mod download
+
+    - name: Install go-licenses
+      run: go install github.com/google/go-licenses@latest
+
+    - name: Check licenses against allow list
+      run: |
+        # Pass allowed licenses as SPDX Identifiers: https://spdx.org/licenses/
+        # The current list is based on Icinga DB, plus GPL-2.0 as both Icinga DB
+        # and this very icinga-notifications are licensed under GPL-2.0.
+        # https://github.com/Icinga/icingadb/blob/v1.1.1/.github/workflows/compliance/check-licenses.sh
+        go-licenses check github.com/icinga/icinga-notifications/... \
+          --allowed_licenses BSD-2-Clause,BSD-3-Clause,GPL-2.0,MIT,MPL-2.0


### PR DESCRIPTION
By utilizing the neat go-licenses[^0] tool, scanning the cached Go dependencies against an allow list of licenses, which is currently leaned from Icinga DB, works quite like a charm.

This, however, only includes Go code and produces warnings for (transitive) included Go Assembly code[^1]. If we are planning to include other non-Go artefacts in the future, those also might need to be identified - REUSE[^2] might help there.

Closes #139.

For an example, take a look at:
- f944c7a751efaebfea155f2b7d401ec5de91d630, which was a successfully run or
- e04222074127af44567da8aba2e168bb7eb8b0ba, where `MPL-2.0` was missing in the allowed licenses, resulting in an adequate error of:
  > Not allowed license MPL-2.0 found for library github.com/go-sql-driver/mysql 

[^0]: https://github.com/google/go-licenses
[^1]: https://github.com/google/go-licenses/issues/120
[^2]: https://reuse.software/