### PR TITLE
Commit transaction for acknowledgements

### DIFF
--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -140,7 +140,17 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event, created bo
 	}
 
 	if ev.Type == event.TypeAcknowledgement {
-		return i.processAcknowledgementEvent(ctx, tx, ev)
+		if err = i.processAcknowledgementEvent(ctx, tx, ev); err != nil {
+			return err
+		}
+
+		if err = tx.Commit(); err != nil {
+			i.logger.Errorw("Can't commit db transaction", zap.Error(err))
+
+			return errors.New("can't commit db transaction")
+		}
+
+		return nil
 	}
 
 	var causedBy types.Int


### PR DESCRIPTION
The early return from `ProcessEvent()` for acknowledgements meant that the commit of the database transaction later in the function would never happen. This was introduced in 4044b188a9f9423be532d11fc0c70b313fc0ca39 which moved the transaction handling into `ProcessEvent()`