### PR TITLE
Incident.RetriggerEscalations: incident_event entry

### DIFF
--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -229,6 +229,10 @@ func (i *Incident) RetriggerEscalations(ev *event.Event) {
 			return err
 		}
 
+		if err = i.AddEvent(ctx, tx, ev); err != nil {
+			return fmt.Errorf("can't insert incident event to the database: %w", err)
+		}
+
 		if err = i.triggerEscalations(ctx, tx, ev, types.Int{}, escalations); err != nil {
 			return err
 		}


### PR DESCRIPTION
Unlike in Incident.ProcessEvent, Incident.RetriggerEscalations does not call Incident.AddEvent on the freshly synchronized Event. By adding this call, an entry to the incident_event table linking Event and Incident will be created.

Closes #151.