### PR TITLE
Distinct "internal" Event Types

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -37,17 +37,19 @@ type Event struct {
 	ID int64 `json:"-"`
 }
 
+// Please keep the following types in alphabetically order and, even more important, make sure that the database type
+// event_type reflects the same values.
 const (
-	TypeState                  = "state"
-	TypeAcknowledgementSet     = "acknowledgement-set"
 	TypeAcknowledgementCleared = "acknowledgement-cleared"
-	TypeInternal               = "internal"
+	TypeAcknowledgementSet     = "acknowledgement-set"
+	TypeCustom                 = "custom"
+	TypeDowntimeEnd            = "downtime-end"
 	TypeDowntimeRemoved        = "downtime-removed"
 	TypeDowntimeStart          = "downtime-start"
-	TypeDowntimeEnd            = "downtime-end"
-	TypeCustom                 = "custom"
-	TypeFlappingStart          = "flapping-start"
 	TypeFlappingEnd            = "flapping-end"
+	TypeFlappingStart          = "flapping-start"
+	TypeIncidentAge            = "incident-age"
+	TypeState                  = "state"
 )
 
 // Validate validates the current event state.
@@ -68,16 +70,17 @@ func (e *Event) Validate() error {
 	switch e.Type {
 	case "":
 		return fmt.Errorf("invalid event: 'type' must not be empty")
-	case TypeState,
-		TypeAcknowledgementSet,
+	case
 		TypeAcknowledgementCleared,
-		TypeInternal,
+		TypeAcknowledgementSet,
+		TypeCustom,
+		TypeDowntimeEnd,
 		TypeDowntimeRemoved,
 		TypeDowntimeStart,
-		TypeDowntimeEnd,
-		TypeCustom,
+		TypeFlappingEnd,
 		TypeFlappingStart,
-		TypeFlappingEnd:
+		TypeIncidentAge,
+		TypeState:
 		return nil
 	default:
 		return fmt.Errorf("invalid event: unsupported event type %q", e.Type)

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -455,8 +455,8 @@ func (i *Incident) evaluateEscalations(eventTime time.Time) ([]*rule.Escalation,
 			i.logger.Info("Reevaluating escalations")
 
 			i.RetriggerEscalations(&event.Event{
-				Type:    event.TypeInternal,
 				Time:    nextEvalAt,
+				Type:    event.TypeIncidentAge,
 				Message: fmt.Sprintf("Incident reached age %v", nextEvalAt.Sub(i.StartedAt.Time())),
 			})
 		})

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -128,8 +128,8 @@ func LoadOpenIncidents(ctx context.Context, db *database.DB, logger *logging.Log
 
 						i.RetriggerEscalations(&event.Event{
 							Time:    time.Now(),
-							Type:    event.TypeInternal,
-							Message: "Incident reevaluation at daemon startup",
+							Type:    event.TypeIncidentAge,
+							Message: fmt.Sprintf("Incident reached age %v (daemon was restarted)", time.Since(i.StartedAt.Time())),
 						})
 					}
 

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -219,13 +219,25 @@ CREATE TABLE object_extra_tag (
     CONSTRAINT pk_object_extra_tag PRIMARY KEY (object_id, tag)
 );
 
+CREATE TYPE event_type AS ENUM (
+    'acknowledgement-cleared',
+    'acknowledgement-set',
+    'custom',
+    'downtime-end',
+    'downtime-removed',
+    'downtime-start',
+    'flapping-end',
+    'flapping-start',
+    'incident-age',
+    'state'
+);
 CREATE TYPE severity AS ENUM ('ok', 'debug', 'info', 'notice', 'warning', 'err', 'crit', 'alert', 'emerg');
 
 CREATE TABLE event (
     id bigserial,
     time bigint NOT NULL,
     object_id bytea NOT NULL REFERENCES object(id),
-    type text NOT NULL,
+    type event_type NOT NULL,
     severity severity,
     message text,
     username citext,

--- a/schema/pgsql/upgrades/030.sql
+++ b/schema/pgsql/upgrades/030.sql
@@ -1,0 +1,16 @@
+CREATE TYPE event_type AS ENUM (
+    'acknowledgement-cleared',
+    'acknowledgement-set',
+    'custom',
+    'downtime-end',
+    'downtime-removed',
+    'downtime-start',
+    'flapping-end',
+    'flapping-start',
+    'incident-age',
+    'state'
+    );
+
+UPDATE event SET type = 'incident-age' WHERE type = 'internal';
+
+ALTER TABLE event ALTER COLUMN type TYPE event_type USING type::event_type;


### PR DESCRIPTION
The "internal" event type was used both for scheduled reevaluations and for initial reevaluations during startup. This type is currently being used at two different points for two distinct topics: scheduled reevaluations and initial reevaluations during startup.

This event type was now split into "reevaluation-scheduled" and "reevaluation-startup" to distinct those types.

To ensure database-level stability, the column type was changed from text to a custom enum.

Closes #162.