### PR TITLE
Drop incident_history.caused_by_incident_history_id

### DIFF
--- a/internal/incident/db_types.go
+++ b/internal/incident/db_types.go
@@ -110,23 +110,22 @@ func (r *RuleRow) TableName() string {
 
 // HistoryRow represents a single incident history database entry.
 type HistoryRow struct {
-	ID                        int64     `db:"id"`
-	IncidentID                int64     `db:"incident_id"`
-	RuleEscalationID          types.Int `db:"rule_escalation_id"`
-	EventID                   types.Int `db:"event_id"`
-	recipient.Key             `db:",inline"`
-	RuleID                    types.Int         `db:"rule_id"`
-	CausedByIncidentHistoryID types.Int         `db:"caused_by_incident_history_id"`
-	Time                      types.UnixMilli   `db:"time"`
-	Type                      HistoryEventType  `db:"type"`
-	ChannelID                 types.Int         `db:"channel_id"`
-	NewSeverity               event.Severity    `db:"new_severity"`
-	OldSeverity               event.Severity    `db:"old_severity"`
-	NewRecipientRole          ContactRole       `db:"new_recipient_role"`
-	OldRecipientRole          ContactRole       `db:"old_recipient_role"`
-	Message                   types.String      `db:"message"`
-	NotificationState         NotificationState `db:"notification_state"`
-	SentAt                    types.UnixMilli   `db:"sent_at"`
+	ID                int64     `db:"id"`
+	IncidentID        int64     `db:"incident_id"`
+	RuleEscalationID  types.Int `db:"rule_escalation_id"`
+	EventID           types.Int `db:"event_id"`
+	recipient.Key     `db:",inline"`
+	RuleID            types.Int         `db:"rule_id"`
+	Time              types.UnixMilli   `db:"time"`
+	Type              HistoryEventType  `db:"type"`
+	ChannelID         types.Int         `db:"channel_id"`
+	NewSeverity       event.Severity    `db:"new_severity"`
+	OldSeverity       event.Severity    `db:"old_severity"`
+	NewRecipientRole  ContactRole       `db:"new_recipient_role"`
+	OldRecipientRole  ContactRole       `db:"old_recipient_role"`
+	Message           types.String      `db:"message"`
+	NotificationState NotificationState `db:"notification_state"`
+	SentAt            types.UnixMilli   `db:"sent_at"`
 }
 
 // TableName implements the contracts.TableNamer interface.

--- a/internal/incident/sync.go
+++ b/internal/incident/sync.go
@@ -149,19 +149,18 @@ func (i *Incident) AddRuleMatched(ctx context.Context, tx *sqlx.Tx, r *rule.Rule
 
 // addPendingNotifications inserts pending notification incident history of the given recipients.
 func (i *Incident) addPendingNotifications(
-	ctx context.Context, tx *sqlx.Tx, ev *event.Event, contactChannels contactChannels, causedBy types.Int,
+	ctx context.Context, tx *sqlx.Tx, ev *event.Event, contactChannels contactChannels,
 ) ([]*NotificationEntry, error) {
 	var notifications []*NotificationEntry
 	for contact, channels := range contactChannels {
 		for chID := range channels {
 			hr := &HistoryRow{
-				Key:                       recipient.ToKey(contact),
-				EventID:                   utils.ToDBInt(ev.ID),
-				Time:                      types.UnixMilli(time.Now()),
-				Type:                      Notified,
-				ChannelID:                 utils.ToDBInt(chID),
-				CausedByIncidentHistoryID: causedBy,
-				NotificationState:         NotificationStatePending,
+				Key:               recipient.ToKey(contact),
+				EventID:           utils.ToDBInt(ev.ID),
+				Time:              types.UnixMilli(time.Now()),
+				Type:              Notified,
+				ChannelID:         utils.ToDBInt(chID),
+				NotificationState: NotificationStatePending,
 			}
 
 			id, err := i.AddHistory(ctx, tx, hr, true)

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -292,7 +292,6 @@ CREATE TABLE incident_history (
     schedule_id bigint REFERENCES schedule(id),
     rule_id bigint REFERENCES rule(id),
     channel_id bigint REFERENCES channel(id),
-    caused_by_incident_history_id bigint REFERENCES incident_history(id),
     time bigint NOT NULL,
     message text,
     type incident_history_event_type NOT NULL,

--- a/schema/pgsql/upgrades/023.sql
+++ b/schema/pgsql/upgrades/023.sql
@@ -1,0 +1,1 @@
+ALTER TABLE incident_history DROP COLUMN caused_by_incident_history_id;


### PR DESCRIPTION
Next to the schema change, the field and its usage was removed from the Go code. This affects continuous changes to signatures.

refs #163.