### PR TITLE
Use standard library instead of x/exp/slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/teambition/rrule-go v1.8.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.22.0
-	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d
 	golang.org/x/sync v0.7.0
 )
 
@@ -41,6 +40,7 @@ require (
 	github.com/ssgreg/journald v1.0.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	go.uber.org/multierr v1.10.0 // indirect
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/config/contact_address.go
+++ b/internal/config/contact_address.go
@@ -5,7 +5,7 @@ import (
 	"github.com/icinga/icinga-notifications/internal/recipient"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func (r *RuntimeConfig) fetchContactAddresses(ctx context.Context, tx *sqlx.Tx) error {


### PR DESCRIPTION
That package is part of the standard library by now, so just use it instead.

`golang.org/x/exp` seems to be still used indirectly by some of our dependencies, so it just moves within `go.mod` instead of being removed.