### PR TITLE
schema: Order incident_history_event_type

### DIFF
--- a/internal/incident/history_event_type.go
+++ b/internal/incident/history_event_type.go
@@ -9,21 +9,22 @@ type HistoryEventType int
 
 const (
 	HistoryEventTypeNull HistoryEventType = iota
-	SeverityChanged
-	RecipientRoleChanged
-	EscalationTriggered
-	RuleMatched
+
 	Opened
+	IncidentSeverityChanged
+	RuleMatched
+	EscalationTriggered
+	RecipientRoleChanged
 	Closed
 	Notified
 )
 
 var historyTypeByName = map[string]HistoryEventType{
-	"incident_severity_changed": SeverityChanged,
-	"recipient_role_changed":    RecipientRoleChanged,
-	"escalation_triggered":      EscalationTriggered,
-	"rule_matched":              RuleMatched,
 	"opened":                    Opened,
+	"incident_severity_changed": IncidentSeverityChanged,
+	"rule_matched":              RuleMatched,
+	"escalation_triggered":      EscalationTriggered,
+	"recipient_role_changed":    RecipientRoleChanged,
 	"closed":                    Closed,
 	"notified":                  Notified,
 }

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -277,7 +277,7 @@ func (i *Incident) processSeverityChangedEvent(ctx context.Context, tx *sqlx.Tx,
 	history := &HistoryRow{
 		EventID:     utils.ToDBInt(ev.ID),
 		Time:        types.UnixMilli(time.Now()),
-		Type:        SeverityChanged,
+		Type:        IncidentSeverityChanged,
 		NewSeverity: newSeverity,
 		OldSeverity: oldSeverity,
 		Message:     utils.ToDBString(ev.Message),

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1,5 +1,14 @@
 CREATE TYPE boolenum AS ENUM ( 'n', 'y' );
-CREATE TYPE incident_history_event_type AS ENUM ( 'incident_severity_changed', 'recipient_role_changed', 'escalation_triggered', 'rule_matched', 'opened', 'closed', 'notified' );
+CREATE TYPE incident_history_event_type AS ENUM (
+    -- Order to be honored for events with identical microsecond timestamps.
+    'opened',
+    'incident_severity_changed',
+    'rule_matched',
+    'escalation_triggered',
+    'recipient_role_changed',
+    'closed',
+    'notified'
+);
 CREATE TYPE frequency_type AS ENUM ( 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY' );
 CREATE TYPE notification_state_type AS ENUM ( 'pending', 'sent', 'failed' );
 
@@ -305,3 +314,6 @@ CREATE TABLE incident_history (
     CONSTRAINT pk_incident_history PRIMARY KEY (id),
     FOREIGN KEY (incident_id, rule_escalation_id) REFERENCES incident_rule_escalation_state(incident_id, rule_escalation_id)
 );
+
+CREATE INDEX idx_incident_history_time_type ON incident_history(time, type);
+COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by time/type';

--- a/schema/pgsql/upgrades/024.sql
+++ b/schema/pgsql/upgrades/024.sql
@@ -1,0 +1,16 @@
+ALTER TYPE incident_history_event_type RENAME TO __incident_history_event_type;
+CREATE TYPE incident_history_event_type AS ENUM (
+    -- Order to be honored for events with identical microsecond timestamps.
+    'opened',
+    'incident_severity_changed',
+    'rule_matched',
+    'escalation_triggered',
+    'recipient_role_changed',
+    'closed',
+    'notified'
+);
+ALTER TABLE incident_history ALTER type TYPE incident_history_event_type USING type::TEXT::incident_history_event_type;
+DROP TYPE __incident_history_event_type;
+
+CREATE INDEX idx_incident_history_time_type ON incident_history(time, type);
+COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by time/type';


### PR DESCRIPTION
Ordering the `incident_history_event_type` enum allows sorting `incident_history` events by `time` and `type` while expecting a logical correct order. This may be necessary because millisecond resolution results in identical timestamps for subsequent entries.

Closes #61.