### PR TITLE
schema: Change as needed for the new rotations

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -123,20 +123,6 @@ CREATE TABLE timeperiod (
     CONSTRAINT pk_timeperiod PRIMARY KEY (id)
 );
 
-CREATE TABLE timeperiod_entry (
-    id bigserial,
-    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
-    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
-    start_time bigint NOT NULL,
-    end_time bigint NOT NULL,
-    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
-    until_time bigint,
-    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
-    rrule text, -- recurrence rule (RFC5545)
-
-    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
-);
-
 CREATE TABLE rotation_member (
     id bigserial,
     rotation_id bigint NOT NULL REFERENCES rotation(id),
@@ -155,6 +141,20 @@ CREATE TABLE rotation_member (
     CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
 
     CONSTRAINT pk_rotation_member PRIMARY KEY (id)
+);
+
+CREATE TABLE timeperiod_entry (
+    id bigserial,
+    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
+    start_time bigint NOT NULL,
+    end_time bigint NOT NULL,
+    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
+    until_time bigint,
+    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
+    rrule text, -- recurrence rule (RFC5545)
+
+    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
 );
 
 CREATE TABLE source (

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -105,6 +105,11 @@ CREATE TABLE rotation (
     -- It is a string as handoffs are restricted to happen only once per day
     first_handoff date NOT NULL,
 
+    -- Set in case the first_handoff was in the past during creation of the rotation.
+    -- It is essentially the creation time of the rotation.
+    -- Used by Web to avoid showing shifts that never happened
+    actual_handoff bigint,
+
     -- each schedule can only have one rotation with a given priority starting at given date
     UNIQUE (schedule_id, priority, first_handoff),
 

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -101,7 +101,13 @@ CREATE TABLE rotation (
     -- Needed exclusively by Web to simplify editing and visualisation
     options text NOT NULL,
 
-    UNIQUE (schedule_id, priority), -- each schedule can only have one rotation with a given priority
+    -- A date in the format 'YYYY-MM-DD' when the first handoff should happen.
+    -- It is a string as handoffs are restricted to happen only once per day
+    first_handoff date NOT NULL,
+
+    -- each schedule can only have one rotation with a given priority starting at given date
+    UNIQUE (schedule_id, priority, first_handoff),
+
     CONSTRAINT pk_rotation PRIMARY KEY (id)
 );
 

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -105,12 +105,12 @@ CREATE TABLE rotation (
     -- It is a string as handoffs are restricted to happen only once per day
     first_handoff date NOT NULL,
 
-    -- Set in case the first_handoff was in the past during creation of the rotation.
-    -- It is essentially the creation time of the rotation.
+    -- Set to the actual time of the first handoff.
+    -- If this is in the past during creation of the rotation, it is set to the creation time.
     -- Used by Web to avoid showing shifts that never happened
-    actual_handoff bigint,
+    actual_handoff bigint NOT NULL,
 
-    -- each schedule can only have one rotation with a given priority starting at given date
+    -- each schedule can only have one rotation with a given priority starting at a given date
     UNIQUE (schedule_id, priority, first_handoff),
 
     CONSTRAINT pk_rotation PRIMARY KEY (id)

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -9,7 +9,7 @@ CREATE TYPE incident_history_event_type AS ENUM (
     'closed',
     'notified'
 );
-CREATE TYPE frequency_type AS ENUM ( 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY' );
+CREATE TYPE rotation_type AS ENUM ( '24-7', 'partial', 'multi' );
 CREATE TYPE notification_state_type AS ENUM ( 'pending', 'sent', 'failed' );
 
 -- IPL ORM renders SQL queries with LIKE operators for all suggestions in the search bar,
@@ -90,9 +90,24 @@ CREATE TABLE schedule (
     CONSTRAINT pk_schedule PRIMARY KEY (id)
 );
 
+CREATE TABLE rotation (
+    id bigserial,
+    schedule_id bigint NOT NULL REFERENCES schedule(id),
+    -- the lower the more important, starting at 0, avoids the need to re-index upon addition
+    priority integer NOT NULL,
+    name text NOT NULL,
+    mode rotation_type NOT NULL,
+    -- JSON with rotation-specific attributes
+    -- Needed exclusively by Web to simplify editing and visualisation
+    options text NOT NULL,
+
+    UNIQUE (schedule_id, priority), -- each schedule can only have one rotation with a given priority
+    CONSTRAINT pk_rotation PRIMARY KEY (id)
+);
+
 CREATE TABLE timeperiod (
     id bigserial,
-    owned_by_schedule_id bigint REFERENCES schedule(id), -- nullable for future standalone timeperiods
+    owned_by_rotation_id bigint REFERENCES rotation(id), -- nullable for future standalone timeperiods
 
     CONSTRAINT pk_timeperiod PRIMARY KEY (id)
 );
@@ -100,35 +115,35 @@ CREATE TABLE timeperiod (
 CREATE TABLE timeperiod_entry (
     id bigserial,
     timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
     start_time bigint NOT NULL,
     end_time bigint NOT NULL,
     -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
     until_time bigint,
     timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
     rrule text, -- recurrence rule (RFC5545)
-    -- Contains the same frequency types as in the rrule string except the `QUARTERLY` one, which is only offered
-    -- by web that is represented as `FREQ=MONTHLY;INTERVAL=3` in a RRule string. So, this should be also ignored
-    -- by the daemon.
-    frequency frequency_type,
-    description text,
 
     CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
 );
 
-CREATE TABLE schedule_member (
-    schedule_id bigint NOT NULL REFERENCES schedule(id),
-    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+CREATE TABLE rotation_member (
+    id bigserial,
+    rotation_id bigint NOT NULL REFERENCES rotation(id),
     contact_id bigint REFERENCES contact(id),
     contactgroup_id bigint REFERENCES contactgroup(id),
+    position integer NOT NULL,
 
-    -- There is no PRIMARY KEY in that table as either contact_id or contactgroup_id should be allowed to be NULL.
-    -- Instead, there are two UNIQUE constraints that prevent duplicate entries. Multiple NULLs are not considered to
-    -- be duplicates, so rows with a contact_id but no contactgroup_id are basically ignored in the UNIQUE constraint
-    -- over contactgroup_id and vice versa. The CHECK constraint below ensures that each row has only non-NULL values
-    -- in one of these constraints.
-    UNIQUE (schedule_id, timeperiod_id, contact_id),
-    UNIQUE (schedule_id, timeperiod_id, contactgroup_id),
-    CHECK (num_nonnulls(contact_id, contactgroup_id) = 1)
+    UNIQUE (rotation_id, position), -- each position in a rotation can only be used once
+
+    -- Two UNIQUE constraints prevent duplicate memberships of the same contact or contactgroup in a single rotation.
+    -- Multiple NULLs are not considered to be duplicates, so rows with a contact_id but no contactgroup_id are
+    -- basically ignored in the UNIQUE constraint over contactgroup_id and vice versa. The CHECK constraint below
+    -- ensures that each row has only non-NULL values in one of these constraints.
+    UNIQUE (rotation_id, contact_id),
+    UNIQUE (rotation_id, contactgroup_id),
+    CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
+
+    CONSTRAINT pk_rotation_member PRIMARY KEY (id)
 );
 
 CREATE TABLE source (

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS rotation (
     -- It is a string as handoffs are restricted to happen only once per day
     first_handoff date NOT NULL,
 
+    -- Set in case the first_handoff was in the past during creation of the rotation.
+    -- It is essentially the creation time of the rotation.
+    -- Used by Web to avoid showing shifts that never happened
+    actual_handoff bigint,
+
     -- each schedule can only have one rotation with a given priority starting at given date
     UNIQUE (schedule_id, priority, first_handoff),
 

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -19,12 +19,12 @@ CREATE TABLE IF NOT EXISTS rotation (
     -- It is a string as handoffs are restricted to happen only once per day
     first_handoff date NOT NULL,
 
-    -- Set in case the first_handoff was in the past during creation of the rotation.
-    -- It is essentially the creation time of the rotation.
+    -- Set to the actual time of the first handoff.
+    -- If this is in the past during creation of the rotation, it is set to the creation time.
     -- Used by Web to avoid showing shifts that never happened
-    actual_handoff bigint,
+    actual_handoff bigint NOT NULL,
 
-    -- each schedule can only have one rotation with a given priority starting at given date
+    -- each schedule can only have one rotation with a given priority starting at a given date
     UNIQUE (schedule_id, priority, first_handoff),
 
     CONSTRAINT pk_rotation PRIMARY KEY (id)

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -45,20 +45,6 @@ CREATE TABLE timeperiod (
     CONSTRAINT pk_timeperiod PRIMARY KEY (id)
 );
 
-CREATE TABLE timeperiod_entry (
-    id bigserial,
-    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
-    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
-    start_time bigint NOT NULL,
-    end_time bigint NOT NULL,
-    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
-    until_time bigint,
-    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
-    rrule text, -- recurrence rule (RFC5545)
-
-    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
-);
-
 CREATE TABLE rotation_member (
     id bigserial,
     rotation_id bigint NOT NULL REFERENCES rotation(id),
@@ -77,6 +63,20 @@ CREATE TABLE rotation_member (
     CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
 
     CONSTRAINT pk_rotation_member PRIMARY KEY (id)
+);
+
+CREATE TABLE timeperiod_entry (
+    id bigserial,
+    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
+    start_time bigint NOT NULL,
+    end_time bigint NOT NULL,
+    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
+    until_time bigint,
+    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
+    rrule text, -- recurrence rule (RFC5545)
+
+    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
 );
 
 ALTER TABLE rule ADD COLUMN timeperiod_id bigint REFERENCES timeperiod(id);

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -1,0 +1,77 @@
+DO $$ BEGIN
+    CREATE TYPE rotation_type AS ENUM ( '24-7', 'partial', 'multi' );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS rotation (
+    id bigserial,
+    schedule_id bigint NOT NULL REFERENCES schedule(id),
+    -- the lower the more important, starting at 0, avoids the need to re-index upon addition
+    priority integer NOT NULL,
+    name text NOT NULL,
+    mode rotation_type NOT NULL,
+    -- JSON with rotation-specific attributes
+    -- Needed exclusively by Web to simplify editing and visualisation
+    options text NOT NULL,
+
+    UNIQUE (schedule_id, priority), -- each schedule can only have one rotation with a given priority
+    CONSTRAINT pk_rotation PRIMARY KEY (id)
+);
+
+ALTER TABLE rule DROP COLUMN timeperiod_id;
+
+DROP TABLE IF EXISTS schedule_member;
+DROP TABLE IF EXISTS rotation_member;
+
+DROP TABLE IF EXISTS timeperiod_entry;
+
+DROP TABLE timeperiod;
+CREATE TABLE timeperiod (
+    id bigserial,
+    owned_by_rotation_id bigint REFERENCES rotation(id), -- nullable for future standalone timeperiods
+
+    CONSTRAINT pk_timeperiod PRIMARY KEY (id)
+);
+
+CREATE TABLE timeperiod_entry (
+    id bigserial,
+    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
+    start_time bigint NOT NULL,
+    end_time bigint NOT NULL,
+    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
+    until_time bigint,
+    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
+    rrule text, -- recurrence rule (RFC5545)
+
+    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
+);
+
+CREATE TABLE rotation_member (
+    id bigserial,
+    rotation_id bigint NOT NULL REFERENCES rotation(id),
+    contact_id bigint REFERENCES contact(id),
+    contactgroup_id bigint REFERENCES contactgroup(id),
+    position integer NOT NULL,
+
+    UNIQUE (rotation_id, position), -- each position in a rotation can only be used once
+
+    -- Two UNIQUE constraints prevent duplicate memberships of the same contact or contactgroup in a single rotation.
+    -- Multiple NULLs are not considered to be duplicates, so rows with a contact_id but no contactgroup_id are
+    -- basically ignored in the UNIQUE constraint over contactgroup_id and vice versa. The CHECK constraint below
+    -- ensures that each row has only non-NULL values in one of these constraints.
+    UNIQUE (rotation_id, contact_id),
+    UNIQUE (rotation_id, contactgroup_id),
+    CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
+
+    CONSTRAINT pk_rotation_member PRIMARY KEY (id)
+);
+
+ALTER TABLE rule ADD COLUMN timeperiod_id bigint REFERENCES timeperiod(id);
+
+DO $$ BEGIN
+    DROP TYPE frequency_type;
+EXCEPTION
+    WHEN undefined_object THEN null;
+END $$;

--- a/schema/pgsql/upgrades/025.sql
+++ b/schema/pgsql/upgrades/025.sql
@@ -15,7 +15,13 @@ CREATE TABLE IF NOT EXISTS rotation (
     -- Needed exclusively by Web to simplify editing and visualisation
     options text NOT NULL,
 
-    UNIQUE (schedule_id, priority), -- each schedule can only have one rotation with a given priority
+    -- A date in the format 'YYYY-MM-DD' when the first handoff should happen.
+    -- It is a string as handoffs are restricted to happen only once per day
+    first_handoff date NOT NULL,
+
+    -- each schedule can only have one rotation with a given priority starting at given date
+    UNIQUE (schedule_id, priority, first_handoff),
+
     CONSTRAINT pk_rotation PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
**rotation**

Holds the configuration of a specific rotation.

*priority*: As the comment states, the lower the more important. Meaning: The shifts described by a rotation with a higher priority (i.e. lower integer) overrides others with a lower one:

![image](https://github.com/Icinga/icinga-notifications/assets/16668527/c15cd27a-b7fb-43fa-b8ac-9c3721af266c)

weekends: 2
anytime: 1
dayshift: 0

*mode*: The configuration type. It describes the pattern the timeperiod entries, associated to each member, have.

**rotation_member**

Maps a member of a rotation to a specific contact or contactgroup.

*position*: Defines the order the member placed at inside the rotation.

![image](https://github.com/Icinga/icinga-notifications/assets/16668527/3faa928b-cb86-4195-b498-dc50ccc28493)

Though, this is probably not of interest to the daemon. As *timeperiod_entry* also describes it.

**timeperiod_entry**

Every member of a rotation has at least one entry associated with it inside the timeperiod of a rotation.

The order of a rotation's members is incorporated in the definition of their entries here.

The daemon just has to interpret them, based on the priority of their rotation, to know who's on duty. Look at the first screenshot again, as the *Result* is what the intended effect should be.