### PR TITLE
Code enhancements for future use

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -3,6 +3,7 @@ package event
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"github.com/icinga/icinga-notifications/internal/utils"
 	"github.com/icinga/icingadb/pkg/icingadb"
@@ -10,6 +11,9 @@ import (
 	"github.com/jmoiron/sqlx"
 	"time"
 )
+
+// ErrSuperfluousStateChange indicates a superfluous state change being ignored and stopping further processing.
+var ErrSuperfluousStateChange = errors.New("ignoring superfluous state change")
 
 // Event received of a specified Type for internal processing.
 //

--- a/internal/icinga2/launcher.go
+++ b/internal/icinga2/launcher.go
@@ -128,7 +128,7 @@ func (launcher *Launcher) launch(src *config.Source) {
 
 			err := incident.ProcessEvent(subCtx, launcher.Db, launcher.Logs, launcher.RuntimeConfig, ev)
 			switch {
-			case errors.Is(err, incident.ErrSuperfluousStateChange):
+			case errors.Is(err, event.ErrSuperfluousStateChange):
 				l.Debugw("Stopped processing event with superfluous state change", zap.Error(err))
 			case err != nil:
 				l.Errorw("Cannot process event", zap.Error(err))

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -260,7 +260,7 @@ func (i *Incident) processSeverityChangedEvent(ctx context.Context, tx *sqlx.Tx,
 	oldSeverity := i.Severity
 	newSeverity := ev.Severity
 	if oldSeverity == newSeverity {
-		err := fmt.Errorf("%w: %s state event from source %d", ErrSuperfluousStateChange, ev.Severity.String(), ev.SourceId)
+		err := fmt.Errorf("%w: %s state event from source %d", event.ErrSuperfluousStateChange, ev.Severity.String(), ev.SourceId)
 		return err
 	}
 

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -18,9 +18,6 @@ import (
 	"time"
 )
 
-// ErrSuperfluousStateChange indicates a superfluous state change being ignored and stopping further processing.
-var ErrSuperfluousStateChange = errors.New("ignoring superfluous state change")
-
 var (
 	currentIncidents   = make(map[*object.Object]*Incident)
 	currentIncidentsMu sync.Mutex
@@ -204,7 +201,7 @@ func GetCurrentIncidents() map[int64]*Incident {
 // This function first gets this Event's object.Object and its incident.Incident. Then, after performing some safety
 // checks, it calls the Incident.ProcessEvent method.
 //
-// The returned error might be wrapped around ErrSuperfluousStateChange.
+// The returned error might be wrapped around event.ErrSuperfluousStateChange.
 func ProcessEvent(
 	ctx context.Context,
 	db *icingadb.DB,
@@ -238,7 +235,7 @@ func ProcessEvent(
 		case ev.Severity != event.SeverityOK:
 			panic(fmt.Sprintf("cannot process event %v with a non-OK state %v without a known incident", ev, ev.Severity))
 		default:
-			return fmt.Errorf("%w: ok state event from source %d", ErrSuperfluousStateChange, ev.SourceId)
+			return fmt.Errorf("%w: ok state event from source %d", event.ErrSuperfluousStateChange, ev.SourceId)
 		}
 	}
 

--- a/internal/incident/sync.go
+++ b/internal/incident/sync.go
@@ -122,7 +122,7 @@ func (i *Incident) AddRecipient(ctx context.Context, tx *sqlx.Tx, escalation *ru
 				_, err := i.AddHistory(ctx, tx, hr, false)
 				if err != nil {
 					i.logger.Errorw(
-						"Failed to insert recipient role changed incident history", zap.String("escalation", escalation.DisplayName()),
+						"Failed to insert recipient role changed incident history", zap.Object("escalation", escalation),
 						zap.String("recipients", r.String()), zap.Error(err),
 					)
 
@@ -136,7 +136,7 @@ func (i *Incident) AddRecipient(ctx context.Context, tx *sqlx.Tx, escalation *ru
 		_, err := tx.NamedExecContext(ctx, stmt, cr)
 		if err != nil {
 			i.logger.Errorw(
-				"Failed to upsert incident recipient", zap.String("escalation", escalation.DisplayName()),
+				"Failed to upsert incident recipient", zap.Object("escalation", escalation),
 				zap.String("recipient", r.String()), zap.Error(err),
 			)
 

--- a/internal/incident/sync.go
+++ b/internal/incident/sync.go
@@ -159,7 +159,7 @@ func (i *Incident) AddRuleMatched(ctx context.Context, tx *sqlx.Tx, r *rule.Rule
 
 // addPendingNotifications inserts pending notification incident history of the given recipients.
 func (i *Incident) addPendingNotifications(
-	ctx context.Context, tx *sqlx.Tx, ev *event.Event, contactChannels contactChannels,
+	ctx context.Context, tx *sqlx.Tx, ev *event.Event, contactChannels rule.ContactChannels,
 ) ([]*NotificationEntry, error) {
 	var notifications []*NotificationEntry
 	for contact, channels := range contactChannels {

--- a/internal/recipient/recipient.go
+++ b/internal/recipient/recipient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/icinga/icinga-notifications/internal/utils"
 	"github.com/icinga/icingadb/pkg/types"
+	"go.uber.org/zap/zapcore"
 	"time"
 )
 
@@ -18,6 +19,23 @@ type Key struct {
 	ContactID  types.Int `db:"contact_id"`
 	GroupID    types.Int `db:"contactgroup_id"`
 	ScheduleID types.Int `db:"schedule_id"`
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+//
+// This allows us to use `zap.Inline(Key)` or `zap.Object("recipient", Key)` wherever fine-grained
+// logging context is needed, without having to add all the individual fields ourselves each time.
+// https://pkg.go.dev/go.uber.org/zap/zapcore#ObjectMarshaler
+func (r Key) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	if r.ContactID.Valid {
+		encoder.AddInt64("contact_id", r.ContactID.Int64)
+	} else if r.GroupID.Valid {
+		encoder.AddInt64("group_id", r.GroupID.Int64)
+	} else if r.ScheduleID.Valid {
+		encoder.AddInt64("schedule_id", r.ScheduleID.Int64)
+	}
+
+	return nil
 }
 
 // MarshalText implements the encoding.TextMarshaler interface to allow JSON marshaling of map[Key]T.


### PR DESCRIPTION
This PR proposes the following improvements in preparation for #188.

- 9502b20958f6cbd085952a41e8c05b771096ebda decouples `contactChannels` from the `incident` package, since we're going to use this recipient channels map elsewhere outside the `incident` package in the future and it seems reasonable to me to move it here to the `rule` package.
- d238b0bf33cf0781a2965745f27ccc88fa20d6a4 implements [`zapcore.ObjectMarshaler`](https://pkg.go.dev/go.uber.org/zap/zapcore#ObjectMarshaler) for the `rule.Escalation` and `recipient.Key` types and allows us to use `zap.Inline(escalation)` or `zap.Object("escalation", escalation)`wherever more logging context is needed without having to add all the individual fields ourselves each time.
- ce8732e7e5de9739a11621293da9e743e1e43233 moves the `ErrSuperfluousStateChange` error type to the `event` package in order to mitigate a cyclic import error with the upcoming changes to non-state event processing support. It kind of also fit into this package.
- 706ed389af7c054545662405965900a00839fae1 drops `incident#AddHistory()` method as it was already quite annoying having to return `types.Int` every single time this method was used. This commit embeds the functionality for `insert and fetch ID` directly into the `HistoryRow` type and nowhere needs to be returned.
- 7ef9aa25f3b82bc8076bca4f5ec483661f0c66ae drops the `create` param from `incident#ProcessEvent()` and `incident#GetCurrent()`, since we can easily determine whether an incident is new based on its `StartedAt` timestamp, and thus, we don't need to pass this info around methods. (Added @sukhwinder33445 as a co-author as the original [idea was from him](https://github.com/Icinga/icinga-notifications/pull/137/commits/2eb858b1994f10bfad74552fa64848126fb01a71), but I've implemented it in a slightly different way).