### PR TITLE
Change schedule configuration to support new rotations

### DIFF
--- a/internal/config/timeperiod.go
+++ b/internal/config/timeperiod.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
@@ -45,9 +44,6 @@ func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error
 
 		if p.Name == "" {
 			p.Name = fmt.Sprintf("Time Period #%d", entry.TimePeriodID)
-			if entry.Description.Valid {
-				p.Name += fmt.Sprintf(" (%s)", entry.Description.String)
-			}
 		}
 
 		err := entry.Init()

--- a/internal/config/timeperiod.go
+++ b/internal/config/timeperiod.go
@@ -2,13 +2,11 @@ package config
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
-	"time"
 )
 
 func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error {
@@ -26,66 +24,37 @@ func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error
 		timePeriodsById[period.ID] = period
 	}
 
-	type TimeperiodEntry struct {
-		ID           int64           `db:"id"`
-		TimePeriodID int64           `db:"timeperiod_id"`
-		StartTime    types.UnixMilli `db:"start_time"`
-		EndTime      types.UnixMilli `db:"end_time"`
-		Timezone     string          `db:"timezone"`
-		RRule        sql.NullString  `db:"rrule"`
-		Description  sql.NullString  `db:"description"`
-	}
-
-	var entryPtr *TimeperiodEntry
+	var entryPtr *timeperiod.Entry
 	stmt = r.db.BuildSelectStmt(entryPtr, entryPtr)
 	r.logger.Debugf("Executing query %q", stmt)
 
-	var entries []*TimeperiodEntry
+	var entries []*timeperiod.Entry
 	if err := tx.SelectContext(ctx, &entries, stmt); err != nil {
 		r.logger.Errorln(err)
 		return err
 	}
 
-	for _, row := range entries {
-		p := timePeriodsById[row.TimePeriodID]
+	for _, entry := range entries {
+		p := timePeriodsById[entry.TimePeriodID]
 		if p == nil {
 			r.logger.Warnw("ignoring entry for unknown timeperiod_id",
-				zap.Int64("timeperiod_entry_id", row.ID),
-				zap.Int64("timeperiod_id", row.TimePeriodID))
+				zap.Int64("timeperiod_entry_id", entry.ID),
+				zap.Int64("timeperiod_id", entry.TimePeriodID))
 			continue
 		}
 
 		if p.Name == "" {
-			p.Name = fmt.Sprintf("Time Period #%d", row.TimePeriodID)
-			if row.Description.Valid {
-				p.Name += fmt.Sprintf(" (%s)", row.Description.String)
+			p.Name = fmt.Sprintf("Time Period #%d", entry.TimePeriodID)
+			if entry.Description.Valid {
+				p.Name += fmt.Sprintf(" (%s)", entry.Description.String)
 			}
 		}
 
-		loc, err := time.LoadLocation(row.Timezone)
-		if err != nil {
-			r.logger.Warnw("ignoring time period entry with unknown timezone",
-				zap.Int64("timeperiod_entry_id", row.ID),
-				zap.String("timezone", row.Timezone),
-				zap.Error(err))
-			continue
-		}
-
-		entry := &timeperiod.Entry{
-			Start:    row.StartTime.Time().Truncate(time.Second).In(loc),
-			End:      row.EndTime.Time().Truncate(time.Second).In(loc),
-			TimeZone: row.Timezone,
-		}
-
-		if row.RRule.Valid {
-			entry.RecurrenceRule = row.RRule.String
-		}
-
-		err = entry.Init()
+		err := entry.Init()
 		if err != nil {
 			r.logger.Warnw("ignoring time period entry",
-				zap.Int64("timeperiod_entry_id", row.ID),
-				zap.String("rrule", entry.RecurrenceRule),
+				zap.Int64("timeperiod_entry_id", entry.ID),
+				zap.String("rrule", entry.RRule.String),
 				zap.Error(err))
 			continue
 		}
@@ -94,9 +63,9 @@ func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error
 
 		r.logger.Debugw("loaded time period entry",
 			zap.String("timeperiod", p.Name),
-			zap.Time("start", entry.Start),
-			zap.Time("end", entry.End),
-			zap.String("rrule", entry.RecurrenceRule))
+			zap.Time("start", entry.StartTime.Time()),
+			zap.Time("end", entry.EndTime.Time()),
+			zap.String("rrule", entry.RRule.String))
 	}
 
 	for _, p := range timePeriodsById {

--- a/internal/config/timeperiod.go
+++ b/internal/config/timeperiod.go
@@ -53,8 +53,7 @@ func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error
 		err := entry.Init()
 		if err != nil {
 			r.logger.Warnw("ignoring time period entry",
-				zap.Int64("timeperiod_entry_id", entry.ID),
-				zap.String("rrule", entry.RRule.String),
+				zap.Object("entry", entry),
 				zap.Error(err))
 			continue
 		}
@@ -62,10 +61,8 @@ func (r *RuntimeConfig) fetchTimePeriods(ctx context.Context, tx *sqlx.Tx) error
 		p.Entries = append(p.Entries, entry)
 
 		r.logger.Debugw("loaded time period entry",
-			zap.String("timeperiod", p.Name),
-			zap.Time("start", entry.StartTime.Time()),
-			zap.Time("end", entry.EndTime.Time()),
-			zap.String("rrule", entry.RRule.String))
+			zap.Object("timeperiod", p),
+			zap.Object("entry", entry))
 	}
 
 	for _, p := range timePeriodsById {

--- a/internal/config/verify.go
+++ b/internal/config/verify.go
@@ -199,34 +199,28 @@ func (r *RuntimeConfig) debugVerifySchedule(id int64, schedule *recipient.Schedu
 		return fmt.Errorf("schedule %p is inconsistent with RuntimeConfig.Schedules[%d] = %p", schedule, id, other)
 	}
 
-	for i, member := range schedule.Members {
-		if member == nil {
-			return fmt.Errorf("Members[%d] is nil", i)
+	for i, rotation := range schedule.Rotations {
+		if rotation == nil {
+			return fmt.Errorf("Rotations[%d] is nil", i)
 		}
 
-		if member.TimePeriod == nil {
-			return fmt.Errorf("Members[%d].TimePeriod is nil", i)
-		}
-
-		if member.Contact == nil && member.ContactGroup == nil {
-			return fmt.Errorf("Members[%d] has neither Contact nor ContactGroup set", i)
-		}
-
-		if member.Contact != nil && member.ContactGroup != nil {
-			return fmt.Errorf("Members[%d] has both Contact and ContactGroup set", i)
-		}
-
-		if member.Contact != nil {
-			err := r.debugVerifyContact(member.Contact.ID, member.Contact)
-			if err != nil {
-				return fmt.Errorf("Contact: %w", err)
+		for j, member := range rotation.Members {
+			if member == nil {
+				return fmt.Errorf("Rotations[%d].Members[%d] is nil", i, j)
 			}
-		}
 
-		if member.ContactGroup != nil {
-			err := r.debugVerifyGroup(member.ContactGroup.ID, member.ContactGroup)
-			if err != nil {
-				return fmt.Errorf("ContactGroup: %w", err)
+			if member.Contact != nil {
+				err := r.debugVerifyContact(member.ContactID.Int64, member.Contact)
+				if err != nil {
+					return fmt.Errorf("Contact: %w", err)
+				}
+			}
+
+			if member.ContactGroup != nil {
+				err := r.debugVerifyGroup(member.ContactGroupID.Int64, member.ContactGroup)
+				if err != nil {
+					return fmt.Errorf("ContactGroup: %w", err)
+				}
 			}
 		}
 	}

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -648,11 +648,20 @@ func (i *Incident) getRecipientsChannel(t time.Time) rule.ContactChannels {
 		}
 
 		if i.IsNotifiable(state.Role) {
-			for _, contact := range r.GetContactsAt(t) {
-				if contactChs[contact] == nil {
-					contactChs[contact] = make(map[int64]bool)
-					contactChs[contact][contact.DefaultChannelID] = true
+			contacts := r.GetContactsAt(t)
+			if len(contacts) > 0 {
+				i.logger.Debugw("Expanded recipient to contacts",
+					zap.Object("recipient", r),
+					zap.Objects("contacts", contacts))
+
+				for _, contact := range contacts {
+					if contactChs[contact] == nil {
+						contactChs[contact] = make(map[int64]bool)
+						contactChs[contact][contact.DefaultChannelID] = true
+					}
 				}
+			} else {
+				i.logger.Warnw("Recipient expanded to no contacts", zap.Object("recipient", r))
 			}
 		}
 	}

--- a/internal/recipient/contact.go
+++ b/internal/recipient/contact.go
@@ -2,6 +2,7 @@ package recipient
 
 import (
 	"database/sql"
+	"go.uber.org/zap/zapcore"
 	"time"
 )
 
@@ -19,6 +20,14 @@ func (c *Contact) String() string {
 
 func (c *Contact) GetContactsAt(t time.Time) []*Contact {
 	return []*Contact{c}
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (c *Contact) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	// Use contact_id as key so that the type is explicit if logged as the Recipient interface.
+	encoder.AddInt64("contact_id", c.ID)
+	encoder.AddString("name", c.FullName)
+	return nil
 }
 
 var _ Recipient = (*Contact)(nil)

--- a/internal/recipient/group.go
+++ b/internal/recipient/group.go
@@ -1,6 +1,9 @@
 package recipient
 
-import "time"
+import (
+	"go.uber.org/zap/zapcore"
+	"time"
+)
 
 type Group struct {
 	ID        int64      `db:"id"`
@@ -19,6 +22,14 @@ func (g *Group) TableName() string {
 
 func (g *Group) String() string {
 	return g.Name
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (g *Group) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	// Use contact_id as key so that the type is explicit if logged as the Recipient interface.
+	encoder.AddInt64("group_id", g.ID)
+	encoder.AddString("name", g.Name)
+	return nil
 }
 
 var _ Recipient = (*Group)(nil)

--- a/internal/recipient/recipient.go
+++ b/internal/recipient/recipient.go
@@ -10,6 +10,7 @@ import (
 
 type Recipient interface {
 	fmt.Stringer
+	zapcore.ObjectMarshaler
 
 	GetContactsAt(t time.Time) []*Contact
 }

--- a/internal/recipient/rotations.go
+++ b/internal/recipient/rotations.go
@@ -1,0 +1,115 @@
+package recipient
+
+import (
+	"cmp"
+	"slices"
+	"time"
+)
+
+// rotationResolver stores all the rotations from a scheduled in a structured way that's suitable for evaluating them.
+type rotationResolver struct {
+	// sortedByPriority is ordered so that the elements at a smaller index have higher precedence.
+	sortedByPriority []*rotationsWithPriority
+}
+
+// rotationsWithPriority stores the different versions of the rotations with the same priority within a single schedule.
+type rotationsWithPriority struct {
+	priority int32
+
+	// sortedByHandoff contains the different version of a specific rotation sorted by their ActualHandoff time.
+	// This allows using binary search to find the active version.
+	sortedByHandoff []*Rotation
+}
+
+// update initializes the rotationResolver with the given rotations, resetting any previously existing state.
+func (r *rotationResolver) update(rotations []*Rotation) {
+	// Group sortedByHandoff by priority using a temporary map with the priority as key.
+	prioMap := make(map[int32]*rotationsWithPriority)
+	for _, rotation := range rotations {
+		p := prioMap[rotation.Priority]
+		if p == nil {
+			p = &rotationsWithPriority{
+				priority: rotation.Priority,
+			}
+			prioMap[rotation.Priority] = p
+		}
+
+		p.sortedByHandoff = append(p.sortedByHandoff, rotation)
+	}
+
+	// Copy it to a slice and sort it by priority so that these can easily be iterated by priority.
+	rs := make([]*rotationsWithPriority, 0, len(prioMap))
+	for _, rotation := range prioMap {
+		rs = append(rs, rotation)
+	}
+	slices.SortFunc(rs, func(a, b *rotationsWithPriority) int {
+		return cmp.Compare(a.priority, b.priority)
+	})
+
+	// Sort the different versions of the same rotation (i.e. same schedule and priority, differing in their handoff
+	// time) by the handoff time so that the currently active version can be found with binary search.
+	for _, rotation := range rs {
+		slices.SortFunc(rotation.sortedByHandoff, func(a, b *Rotation) int {
+			return a.ActualHandoff.Time().Compare(b.ActualHandoff.Time())
+		})
+	}
+
+	r.sortedByPriority = rs
+}
+
+// getRotationsAt returns a slice of active rotations at the given time.
+//
+// For priority, there may be at most one active rotation version. This function return all rotation versions that
+// are active at the given time t, ordered by priority (lower index has higher precedence).
+func (r *rotationResolver) getRotationsAt(t time.Time) []*Rotation {
+	rotations := make([]*Rotation, 0, len(r.sortedByPriority))
+
+	for _, w := range r.sortedByPriority {
+		i, found := slices.BinarySearchFunc(w.sortedByHandoff, t, func(rotation *Rotation, t time.Time) int {
+			return rotation.ActualHandoff.Time().Compare(t)
+		})
+
+		// If a rotation version with sortedByHandoff[i].ActualHandoff == t is found, it just became valid and should be
+		// used. Otherwise, BinarySearchFunc returns the first index i after t so that:
+		//
+		//   sortedByHandoff[i-1].ActualHandoff < t < sortedByHandoff[i].ActualHandoff
+		//
+		// Thus, the version at index i becomes active after t and the preceding one is still active.
+		if !found {
+			i--
+		}
+
+		// If all rotation versions have ActualHandoff > t, there is none that's currently active and i is negative.
+		if i >= 0 {
+			rotations = append(rotations, w.sortedByHandoff[i])
+		}
+	}
+
+	return rotations
+}
+
+// getContactsAt evaluates the rotations by priority and returns all contacts active at the given time.
+func (r *rotationResolver) getContactsAt(t time.Time) []*Contact {
+	rotations := r.getRotationsAt(t)
+	for _, rotation := range rotations {
+		for _, member := range rotation.Members {
+			for _, entry := range member.TimePeriodEntries {
+				if entry.Contains(t) {
+					var contacts []*Contact
+
+					if member.Contact != nil {
+						contacts = append(contacts, member.Contact)
+					}
+
+					if member.ContactGroup != nil {
+						contacts = append(contacts, member.ContactGroup.Members...)
+					}
+
+					return contacts
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/recipient/rotations_test.go
+++ b/internal/recipient/rotations_test.go
@@ -1,0 +1,169 @@
+package recipient
+
+import (
+	"database/sql"
+	"github.com/icinga/icinga-go-library/types"
+	"github.com/icinga/icinga-notifications/internal/timeperiod"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_rotationResolver_getCurrentRotations(t *testing.T) {
+	contactWeekday := &Contact{FullName: "Weekday Non-Noon"}
+	contactWeekdayNoon := &Contact{FullName: "Weekday Noon"}
+	contactWeekend2024a := &Contact{FullName: "Weekend 2024 A"}
+	contactWeekend2024b := &Contact{FullName: "Weekend 2024 B"}
+	contactWeekend2025a := &Contact{FullName: "Weekend 2025 A"}
+	contactWeekend2025b := &Contact{FullName: "Weekend 2025 B"}
+
+	// Helper function to parse strings into time.Time interpreted as UTC.
+	// Accepts values like "2006-01-02 15:04:05" and "2006-01-02" (assuming 00:00:00 as time).
+	parse := func(s string) time.Time {
+		var format string
+
+		switch len(s) {
+		case len(time.DateTime):
+			format = time.DateTime
+		case len(time.DateOnly):
+			format = time.DateOnly
+		}
+
+		t, err := time.ParseInLocation(format, s, time.UTC)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+
+	var s rotationResolver
+	s.update([]*Rotation{
+		// Weekend rotation starting 2024, alternating between contacts contactWeekend2024a and contactWeekend2024b
+		{
+			ActualHandoff: types.UnixMilli(parse("2024-01-01")),
+			Priority:      0,
+			Members: []*RotationMember{
+				{
+					Contact: contactWeekend2024a,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						1: {
+							StartTime: types.UnixMilli(parse("2024-01-06")), // Saturday
+							EndTime:   types.UnixMilli(parse("2024-01-07")), // Sunday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA,SU", Valid: true},
+						},
+					},
+				}, {
+					Contact: contactWeekend2024b,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						2: {
+							StartTime: types.UnixMilli(parse("2024-01-13")), // Saturday
+							EndTime:   types.UnixMilli(parse("2024-01-14")), // Sunday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA,SU", Valid: true},
+						},
+					},
+				},
+			},
+		},
+
+		// Weekend rotation starting 2025 and replacing the previous one,
+		// alternating between contacts contactWeekend2025a and contactWeekend2025b
+		{
+			ActualHandoff: types.UnixMilli(parse("2025-01-01")),
+			Priority:      0,
+			Members: []*RotationMember{
+				{
+					Contact: contactWeekend2025a,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						3: {
+							StartTime: types.UnixMilli(parse("2025-01-04")), // Saturday
+							EndTime:   types.UnixMilli(parse("2025-01-05")), // Sunday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA,SU", Valid: true},
+						},
+					},
+				}, {
+					Contact: contactWeekend2025b,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						4: {
+							StartTime: types.UnixMilli(parse("2025-01-11")), // Saturday
+							EndTime:   types.UnixMilli(parse("2025-01-12")), // Sunday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SA,SU", Valid: true},
+						},
+					},
+				},
+			},
+		},
+
+		// Weekday rotations starting 2024, one for contactWeekday every day from 8 to 20 o'clock,
+		// with an override for 12 to 14 o'clock with contactWeekdayNoon.
+		{
+			ActualHandoff: types.UnixMilli(parse("2024-01-01")),
+			Priority:      1,
+			Members: []*RotationMember{
+				{
+					Contact: contactWeekdayNoon,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						5: {
+							StartTime: types.UnixMilli(parse("2024-01-01 12:00:00")), // Monday
+							EndTime:   types.UnixMilli(parse("2024-01-01 14:00:00")), // Monday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR", Valid: true},
+						},
+					},
+				},
+			},
+		}, {
+			ActualHandoff: types.UnixMilli(parse("2024-01-01")),
+			Priority:      2,
+			Members: []*RotationMember{
+				{
+					Contact: contactWeekday,
+					TimePeriodEntries: map[int64]*timeperiod.Entry{
+						6: {
+							StartTime: types.UnixMilli(parse("2024-01-01 08:00:00")), // Monday
+							EndTime:   types.UnixMilli(parse("2024-01-01 20:00:00")), // Monday
+							Timezone:  "UTC",
+							RRule:     sql.NullString{String: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR", Valid: true},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	for ts := parse("2023-01-01"); ts.Before(parse("2027-01-01")); ts = ts.Add(30 * time.Minute) {
+		got := s.getContactsAt(ts)
+
+		switch ts.Weekday() {
+		case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday:
+			if y, h := ts.Year(), ts.Hour(); y >= 2024 && 12 <= h && h < 14 {
+				if assert.Lenf(t, got, 1, "resolving rotations on %v should return one contact", ts) {
+					assert.Equal(t, contactWeekdayNoon, got[0])
+				}
+			} else if y >= 2024 && 8 <= h && h < 20 {
+				if assert.Lenf(t, got, 1, "resolving rotations on %v should return one contact", ts) {
+					assert.Equal(t, contactWeekday, got[0])
+				}
+			} else {
+				assert.Emptyf(t, got, "resolving rotations on %v should return no contacts", ts)
+			}
+
+		case time.Saturday, time.Sunday:
+			switch y := ts.Year(); {
+			case y == 2024:
+				if assert.Lenf(t, got, 1, "resolving rotations on %v return one contact", ts) {
+					assert.Contains(t, []*Contact{contactWeekend2024a, contactWeekend2024b}, got[0])
+				}
+			case y >= 2025:
+				if assert.Lenf(t, got, 1, "resolving rotations on %v return one contact", ts) {
+					assert.Contains(t, []*Contact{contactWeekend2025a, contactWeekend2025b}, got[0])
+				}
+			default:
+				assert.Emptyf(t, got, "resolving rotations on %v should return no contacts", ts)
+			}
+		}
+	}
+}

--- a/internal/recipient/schedule.go
+++ b/internal/recipient/schedule.go
@@ -2,51 +2,70 @@ package recipient
 
 import (
 	"database/sql"
+	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
+	"go.uber.org/zap/zapcore"
 	"time"
 )
 
 type Schedule struct {
-	ID         int64                `db:"id"`
-	Name       string               `db:"name"`
-	Members    []*Member            `db:"-"`
-	MemberRows []*ScheduleMemberRow `db:"-"`
+	ID   int64  `db:"id"`
+	Name string `db:"name"`
+
+	Rotations        []*Rotation `db:"-"`
+	rotationResolver rotationResolver
 }
 
-type Member struct {
-	TimePeriod   *timeperiod.TimePeriod
-	Contact      *Contact
-	ContactGroup *Group
+// RefreshRotations updates the internally cached rotations.
+//
+// This must be called after the Rotations member was updated for the change to become active.
+func (s *Schedule) RefreshRotations() {
+	s.rotationResolver.update(s.Rotations)
 }
 
-type ScheduleMemberRow struct {
-	ScheduleID   int64         `db:"schedule_id"`
-	TimePeriodID int64         `db:"timeperiod_id"`
-	ContactID    sql.NullInt64 `db:"contact_id"`
-	GroupID      sql.NullInt64 `db:"contactgroup_id"`
+type Rotation struct {
+	ID            int64             `db:"id"`
+	ScheduleID    int64             `db:"schedule_id"`
+	ActualHandoff types.UnixMilli   `db:"actual_handoff"`
+	Priority      int32             `db:"priority"`
+	Name          string            `db:"name"`
+	Members       []*RotationMember `db:"-"`
 }
 
-func (s *ScheduleMemberRow) TableName() string {
-	return "schedule_member"
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (r *Rotation) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddInt64("id", r.ID)
+	encoder.AddInt64("schedule_id", r.ScheduleID)
+	encoder.AddInt32("priority", r.Priority)
+	encoder.AddString("name", r.Name)
+	return nil
+}
+
+type RotationMember struct {
+	ID                int64                       `db:"id"`
+	RotationID        int64                       `db:"rotation_id"`
+	Contact           *Contact                    `db:"-"`
+	ContactID         sql.NullInt64               `db:"contact_id"`
+	ContactGroup      *Group                      `db:"-"`
+	ContactGroupID    sql.NullInt64               `db:"contactgroup_id"`
+	TimePeriodEntries map[int64]*timeperiod.Entry `db:"-"`
+}
+
+func (r *RotationMember) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddInt64("id", r.ID)
+	encoder.AddInt64("rotation_id", r.RotationID)
+	if r.ContactID.Valid {
+		encoder.AddInt64("contact_id", r.ContactID.Int64)
+	}
+	if r.ContactGroupID.Valid {
+		encoder.AddInt64("contact_group_id", r.ContactGroupID.Int64)
+	}
+	return nil
 }
 
 // GetContactsAt returns the contacts that are active in the schedule at the given time.
 func (s *Schedule) GetContactsAt(t time.Time) []*Contact {
-	var contacts []*Contact
-
-	for _, m := range s.Members {
-		if m.TimePeriod.Contains(t) {
-			if m.Contact != nil {
-				contacts = append(contacts, m.Contact)
-			}
-
-			if m.ContactGroup != nil {
-				contacts = append(contacts, m.ContactGroup.Members...)
-			}
-		}
-	}
-
-	return contacts
+	return s.rotationResolver.getContactsAt(t)
 }
 
 func (s *Schedule) String() string {

--- a/internal/recipient/schedule.go
+++ b/internal/recipient/schedule.go
@@ -23,6 +23,14 @@ func (s *Schedule) RefreshRotations() {
 	s.rotationResolver.update(s.Rotations)
 }
 
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (s *Schedule) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	// Use schedule_id as key so that the type is explicit if logged as the Recipient interface.
+	encoder.AddInt64("schedule_id", s.ID)
+	encoder.AddString("name", s.Name)
+	return nil
+}
+
 type Rotation struct {
 	ID            int64             `db:"id"`
 	ScheduleID    int64             `db:"schedule_id"`

--- a/internal/timeperiod/timeperiod.go
+++ b/internal/timeperiod/timeperiod.go
@@ -5,6 +5,7 @@ import (
 	"github.com/icinga/icingadb/pkg/types"
 	"github.com/pkg/errors"
 	"github.com/teambition/rrule-go"
+	"go.uber.org/zap/zapcore"
 	"log"
 	"time"
 )
@@ -17,6 +18,13 @@ type TimePeriod struct {
 
 func (p *TimePeriod) TableName() string {
 	return "timeperiod"
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (p *TimePeriod) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddInt64("id", p.ID)
+	encoder.AddString("name", p.Name)
+	return nil
 }
 
 // Contains returns whether a point in time t is covered by this time period, i.e. there is an entry covering it.
@@ -66,6 +74,18 @@ type Entry struct {
 // TableName implements the contracts.TableNamer interface.
 func (e *Entry) TableName() string {
 	return "timeperiod_entry"
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface.
+func (e *Entry) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddInt64("id", e.ID)
+	encoder.AddTime("start", e.StartTime.Time())
+	encoder.AddTime("end", e.EndTime.Time())
+	encoder.AddString("timezone", e.Timezone)
+	if e.RRule.Valid {
+		encoder.AddString("rrule", e.RRule.String)
+	}
+	return nil
 }
 
 // Init prepares the Entry for use after being read from the database.

--- a/internal/timeperiod/timeperiod.go
+++ b/internal/timeperiod/timeperiod.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/teambition/rrule-go"
 	"go.uber.org/zap/zapcore"
-	"log"
 	"time"
 )
 
@@ -129,10 +128,11 @@ func (e *Entry) Init() error {
 }
 
 // Contains returns whether a point in time t is covered by this entry.
+//
+// This function may only be called after a successful call to Init().
 func (e *Entry) Contains(t time.Time) bool {
-	err := e.Init()
-	if err != nil {
-		log.Printf("Can't initialize entry: %s", err)
+	if !e.initialized {
+		panic("timeperiod.Entry: called Contains() before Init()")
 	}
 
 	if t.Before(e.StartTime.Time()) {
@@ -156,10 +156,11 @@ func (e *Entry) Contains(t time.Time) bool {
 // NextTransition returns the next recurrence start or end of this entry relative to the given time inclusively.
 // This function returns also time.Time's zero value if there is no transition that starts/ends at/after the
 // specified time.
+//
+// This function may only be called after a successful call to Init().
 func (e *Entry) NextTransition(t time.Time) time.Time {
-	err := e.Init()
-	if err != nil {
-		log.Printf("Can't initialize entry: %s", err)
+	if !e.initialized {
+		panic("timeperiod.Entry: called NextTransition() before Init()")
 	}
 
 	if t.Before(e.StartTime.Time()) {

--- a/internal/timeperiod/timeperiod.go
+++ b/internal/timeperiod/timeperiod.go
@@ -2,7 +2,7 @@ package timeperiod
 
 import (
 	"database/sql"
-	"github.com/icinga/icingadb/pkg/types"
+	"github.com/icinga/icinga-go-library/types"
 	"github.com/pkg/errors"
 	"github.com/teambition/rrule-go"
 	"go.uber.org/zap/zapcore"
@@ -64,7 +64,6 @@ type Entry struct {
 	EndTime          types.UnixMilli `db:"end_time"`
 	Timezone         string          `db:"timezone"`
 	RRule            sql.NullString  `db:"rrule"` // RFC5545 RRULE
-	Description      sql.NullString  `db:"description"`
 	RotationMemberID sql.NullInt64   `db:"rotation_member_id"`
 
 	initialized bool

--- a/internal/timeperiod/timeperiod_test.go
+++ b/internal/timeperiod/timeperiod_test.go
@@ -3,8 +3,8 @@ package timeperiod_test
 import (
 	"database/sql"
 	"fmt"
+	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
-	"github.com/icinga/icingadb/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/teambition/rrule-go"
 	"testing"

--- a/internal/timeperiod/timeperiod_test.go
+++ b/internal/timeperiod/timeperiod_test.go
@@ -1,8 +1,10 @@
 package timeperiod_test
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
+	"github.com/icinga/icingadb/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/teambition/rrule-go"
 	"testing"
@@ -19,9 +21,13 @@ func TestEntry(t *testing.T) {
 		end := berlinTime("2023-03-01 11:00:00")
 		until := berlinTime("2023-03-03 09:00:00")
 		e := &timeperiod.Entry{
-			Start:          start,
-			End:            end,
-			RecurrenceRule: fmt.Sprintf("FREQ=DAILY;UNTIL=%s", until.UTC().Format(rrule.DateTimeFormat)),
+			StartTime: types.UnixMilli(start),
+			EndTime:   types.UnixMilli(end),
+			Timezone:  berlin,
+			RRule: sql.NullString{
+				String: fmt.Sprintf("FREQ=DAILY;UNTIL=%s", until.UTC().Format(rrule.DateTimeFormat)),
+				Valid:  true,
+			},
 		}
 
 		t.Run("TimeAtFirstRecurrenceStart", func(t *testing.T) {
@@ -73,9 +79,10 @@ func TestEntry(t *testing.T) {
 			start := berlinTime("2023-03-25 01:00:00")
 			end := berlinTime("2023-03-25 02:30:00")
 			e := &timeperiod.Entry{
-				Start:          start,
-				End:            end,
-				RecurrenceRule: "FREQ=DAILY",
+				StartTime: types.UnixMilli(start),
+				EndTime:   types.UnixMilli(end),
+				Timezone:  berlin,
+				RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 			}
 
 			assert.True(t, e.Contains(start))
@@ -95,9 +102,10 @@ func TestEntry(t *testing.T) {
 		start := berlinTime("2023-03-01 08:00:00")
 		end := berlinTime("2023-03-01 12:30:00")
 		e := &timeperiod.Entry{
-			Start:          start,
-			End:            end,
-			RecurrenceRule: "FREQ=DAILY",
+			StartTime: types.UnixMilli(start),
+			EndTime:   types.UnixMilli(end),
+			Timezone:  berlin,
+			RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 		}
 
 		t.Run("TimeAtFirstRecurrenceStart", func(t *testing.T) {
@@ -124,9 +132,10 @@ func TestEntry(t *testing.T) {
 			start := berlinTime("2023-03-25 01:00:00")
 			end := berlinTime("2023-03-25 02:30:00")
 			e := &timeperiod.Entry{
-				Start:          start,
-				End:            end,
-				RecurrenceRule: "FREQ=DAILY",
+				StartTime: types.UnixMilli(start),
+				EndTime:   types.UnixMilli(end),
+				Timezone:  berlin,
+				RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 			}
 
 			assert.Equal(t, end, e.NextTransition(start), "next transition should match the first recurrence end")
@@ -152,9 +161,10 @@ func TestTimePeriodTransitions(t *testing.T) {
 		p := &timeperiod.TimePeriod{
 			Name: "Transition Test",
 			Entries: []*timeperiod.Entry{{
-				Start:          start,
-				End:            end,
-				RecurrenceRule: "FREQ=DAILY",
+				StartTime: types.UnixMilli(start),
+				EndTime:   types.UnixMilli(end),
+				Timezone:  berlin,
+				RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 			}},
 		}
 
@@ -170,14 +180,16 @@ func TestTimePeriodTransitions(t *testing.T) {
 			Name: "Transition Test",
 			Entries: []*timeperiod.Entry{
 				{
-					Start:          start,
-					End:            end,
-					RecurrenceRule: "FREQ=HOURLY;BYHOUR=1,3,5,7,9,11,13,15",
+					StartTime: types.UnixMilli(start),
+					EndTime:   types.UnixMilli(end),
+					Timezone:  berlin,
+					RRule:     sql.NullString{String: "FREQ=HOURLY;BYHOUR=1,3,5,7,9,11,13,15", Valid: true},
 				},
 				{
-					Start:          berlinTime("2023-03-27 08:00:00"),
-					End:            berlinTime("2023-03-27 08:30:00"),
-					RecurrenceRule: "FREQ=HOURLY;BYHOUR=0,2,4,6,8,10,12,14",
+					StartTime: types.UnixMilli(berlinTime("2023-03-27 08:00:00")),
+					EndTime:   types.UnixMilli(berlinTime("2023-03-27 08:30:00")),
+					Timezone:  berlin,
+					RRule:     sql.NullString{String: "FREQ=HOURLY;BYHOUR=0,2,4,6,8,10,12,14", Valid: true},
 				},
 			},
 		}
@@ -206,8 +218,10 @@ func TestTimePeriodTransitions(t *testing.T) {
 	})
 }
 
+const berlin = "Europe/Berlin"
+
 func berlinTime(value string) time.Time {
-	loc, err := time.LoadLocation("Europe/Berlin")
+	loc, err := time.LoadLocation(berlin)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/timeperiod/timeperiod_test.go
+++ b/internal/timeperiod/timeperiod_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/teambition/rrule-go"
 	"testing"
 	"time"
@@ -29,6 +30,8 @@ func TestEntry(t *testing.T) {
 				Valid:  true,
 			},
 		}
+
+		require.NoError(t, e.Init())
 
 		t.Run("TimeAtFirstRecurrenceStart", func(t *testing.T) {
 			assert.True(t, e.Contains(start))
@@ -85,6 +88,8 @@ func TestEntry(t *testing.T) {
 				RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 			}
 
+			require.NoError(t, e.Init())
+
 			assert.True(t, e.Contains(start))
 
 			tz := time.FixedZone("CET", 60*60)
@@ -107,6 +112,8 @@ func TestEntry(t *testing.T) {
 			Timezone:  berlin,
 			RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 		}
+
+		require.NoError(t, e.Init())
 
 		t.Run("TimeAtFirstRecurrenceStart", func(t *testing.T) {
 			assert.Equal(t, end, e.NextTransition(start))
@@ -137,6 +144,7 @@ func TestEntry(t *testing.T) {
 				Timezone:  berlin,
 				RRule:     sql.NullString{String: "FREQ=DAILY", Valid: true},
 			}
+			require.NoError(t, e.Init())
 
 			assert.Equal(t, end, e.NextTransition(start), "next transition should match the first recurrence end")
 
@@ -168,6 +176,10 @@ func TestTimePeriodTransitions(t *testing.T) {
 			}},
 		}
 
+		for _, e := range p.Entries {
+			require.NoError(t, e.Init())
+		}
+
 		assert.Equal(t, end, p.NextTransition(start), "next transition should match the interval end")
 	})
 
@@ -192,6 +204,10 @@ func TestTimePeriodTransitions(t *testing.T) {
 					RRule:     sql.NullString{String: "FREQ=HOURLY;BYHOUR=0,2,4,6,8,10,12,14", Valid: true},
 				},
 			},
+		}
+
+		for _, e := range p.Entries {
+			require.NoError(t, e.Init())
 		}
 
 		assert.Equal(t, end, p.NextTransition(start), "next transition should match the interval end")

--- a/schema/pgsql/upgrades/026.sql
+++ b/schema/pgsql/upgrades/026.sql
@@ -1,48 +1,18 @@
-DO $$ BEGIN
-    CREATE TYPE rotation_type AS ENUM ( '24-7', 'partial', 'multi' );
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
+-- IMPORTANT: This schema upgrade removes all schedule-related configuration as it was changed in an incompatible way!
 
-CREATE TABLE IF NOT EXISTS rotation (
+CREATE TYPE rotation_type AS ENUM ( '24-7', 'partial', 'multi' );
+
+CREATE TABLE rotation (
     id bigserial,
     schedule_id bigint NOT NULL REFERENCES schedule(id),
-    -- the lower the more important, starting at 0, avoids the need to re-index upon addition
     priority integer NOT NULL,
     name text NOT NULL,
     mode rotation_type NOT NULL,
-    -- JSON with rotation-specific attributes
-    -- Needed exclusively by Web to simplify editing and visualisation
     options text NOT NULL,
-
-    -- A date in the format 'YYYY-MM-DD' when the first handoff should happen.
-    -- It is a string as handoffs are restricted to happen only once per day
     first_handoff date NOT NULL,
-
-    -- Set to the actual time of the first handoff.
-    -- If this is in the past during creation of the rotation, it is set to the creation time.
-    -- Used by Web to avoid showing shifts that never happened
     actual_handoff bigint NOT NULL,
-
-    -- each schedule can only have one rotation with a given priority starting at a given date
     UNIQUE (schedule_id, priority, first_handoff),
-
     CONSTRAINT pk_rotation PRIMARY KEY (id)
-);
-
-ALTER TABLE rule DROP COLUMN timeperiod_id;
-
-DROP TABLE IF EXISTS schedule_member;
-DROP TABLE IF EXISTS rotation_member;
-
-DROP TABLE IF EXISTS timeperiod_entry;
-
-DROP TABLE timeperiod;
-CREATE TABLE timeperiod (
-    id bigserial,
-    owned_by_rotation_id bigint REFERENCES rotation(id), -- nullable for future standalone timeperiods
-
-    CONSTRAINT pk_timeperiod PRIMARY KEY (id)
 );
 
 CREATE TABLE rotation_member (
@@ -51,38 +21,25 @@ CREATE TABLE rotation_member (
     contact_id bigint REFERENCES contact(id),
     contactgroup_id bigint REFERENCES contactgroup(id),
     position integer NOT NULL,
-
-    UNIQUE (rotation_id, position), -- each position in a rotation can only be used once
-
-    -- Two UNIQUE constraints prevent duplicate memberships of the same contact or contactgroup in a single rotation.
-    -- Multiple NULLs are not considered to be duplicates, so rows with a contact_id but no contactgroup_id are
-    -- basically ignored in the UNIQUE constraint over contactgroup_id and vice versa. The CHECK constraint below
-    -- ensures that each row has only non-NULL values in one of these constraints.
+    UNIQUE (rotation_id, position),
     UNIQUE (rotation_id, contact_id),
     UNIQUE (rotation_id, contactgroup_id),
     CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
-
     CONSTRAINT pk_rotation_member PRIMARY KEY (id)
 );
 
-CREATE TABLE timeperiod_entry (
-    id bigserial,
-    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
-    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
-    start_time bigint NOT NULL,
-    end_time bigint NOT NULL,
-    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
-    until_time bigint,
-    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
-    rrule text, -- recurrence rule (RFC5545)
+DROP TABLE schedule_member;
 
-    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
-);
+DELETE FROM timeperiod_entry WHERE timeperiod_id IN (SELECT id FROM timeperiod WHERE owned_by_schedule_id IS NOT NULL);
+DELETE FROM timeperiod WHERE owned_by_schedule_id IS NOT NULL;
 
-ALTER TABLE rule ADD COLUMN timeperiod_id bigint REFERENCES timeperiod(id);
+ALTER TABLE timeperiod
+    DROP COLUMN owned_by_schedule_id,
+    ADD COLUMN owned_by_rotation_id bigint REFERENCES rotation(id);
 
-DO $$ BEGIN
-    DROP TYPE frequency_type;
-EXCEPTION
-    WHEN undefined_object THEN null;
-END $$;
+ALTER TABLE timeperiod_entry
+    DROP COLUMN frequency,
+    DROP COLUMN description,
+    ADD COLUMN rotation_member_id bigint REFERENCES rotation_member(id);
+
+DROP TYPE frequency_type;

--- a/schema/pgsql/upgrades/026.sql
+++ b/schema/pgsql/upgrades/026.sql
@@ -1,0 +1,88 @@
+DO $$ BEGIN
+    CREATE TYPE rotation_type AS ENUM ( '24-7', 'partial', 'multi' );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS rotation (
+    id bigserial,
+    schedule_id bigint NOT NULL REFERENCES schedule(id),
+    -- the lower the more important, starting at 0, avoids the need to re-index upon addition
+    priority integer NOT NULL,
+    name text NOT NULL,
+    mode rotation_type NOT NULL,
+    -- JSON with rotation-specific attributes
+    -- Needed exclusively by Web to simplify editing and visualisation
+    options text NOT NULL,
+
+    -- A date in the format 'YYYY-MM-DD' when the first handoff should happen.
+    -- It is a string as handoffs are restricted to happen only once per day
+    first_handoff date NOT NULL,
+
+    -- Set to the actual time of the first handoff.
+    -- If this is in the past during creation of the rotation, it is set to the creation time.
+    -- Used by Web to avoid showing shifts that never happened
+    actual_handoff bigint NOT NULL,
+
+    -- each schedule can only have one rotation with a given priority starting at a given date
+    UNIQUE (schedule_id, priority, first_handoff),
+
+    CONSTRAINT pk_rotation PRIMARY KEY (id)
+);
+
+ALTER TABLE rule DROP COLUMN timeperiod_id;
+
+DROP TABLE IF EXISTS schedule_member;
+DROP TABLE IF EXISTS rotation_member;
+
+DROP TABLE IF EXISTS timeperiod_entry;
+
+DROP TABLE timeperiod;
+CREATE TABLE timeperiod (
+    id bigserial,
+    owned_by_rotation_id bigint REFERENCES rotation(id), -- nullable for future standalone timeperiods
+
+    CONSTRAINT pk_timeperiod PRIMARY KEY (id)
+);
+
+CREATE TABLE rotation_member (
+    id bigserial,
+    rotation_id bigint NOT NULL REFERENCES rotation(id),
+    contact_id bigint REFERENCES contact(id),
+    contactgroup_id bigint REFERENCES contactgroup(id),
+    position integer NOT NULL,
+
+    UNIQUE (rotation_id, position), -- each position in a rotation can only be used once
+
+    -- Two UNIQUE constraints prevent duplicate memberships of the same contact or contactgroup in a single rotation.
+    -- Multiple NULLs are not considered to be duplicates, so rows with a contact_id but no contactgroup_id are
+    -- basically ignored in the UNIQUE constraint over contactgroup_id and vice versa. The CHECK constraint below
+    -- ensures that each row has only non-NULL values in one of these constraints.
+    UNIQUE (rotation_id, contact_id),
+    UNIQUE (rotation_id, contactgroup_id),
+    CHECK (num_nonnulls(contact_id, contactgroup_id) = 1),
+
+    CONSTRAINT pk_rotation_member PRIMARY KEY (id)
+);
+
+CREATE TABLE timeperiod_entry (
+    id bigserial,
+    timeperiod_id bigint NOT NULL REFERENCES timeperiod(id),
+    rotation_member_id bigint REFERENCES rotation_member(id), -- nullable for future standalone timeperiods
+    start_time bigint NOT NULL,
+    end_time bigint NOT NULL,
+    -- Is needed by icinga-notifications-web to prefilter entries, which matches until this time and should be ignored by the daemon.
+    until_time bigint,
+    timezone text NOT NULL, -- e.g. 'Europe/Berlin', relevant for evaluating rrule (DST changes differ between zones)
+    rrule text, -- recurrence rule (RFC5545)
+
+    CONSTRAINT pk_timeperiod_entry PRIMARY KEY (id)
+);
+
+ALTER TABLE rule ADD COLUMN timeperiod_id bigint REFERENCES timeperiod(id);
+
+DO $$ BEGIN
+    DROP TYPE frequency_type;
+EXCEPTION
+    WHEN undefined_object THEN null;
+END $$;


### PR DESCRIPTION
This is a fundamental and incompatible change to how schedules are defined. Now, a schedule consists of a list of rotations that's ordered by priority. Each rotation contains multiple members where each is either a contact or a contact group. Each member is linked to some timeperiod entries which defines when this member is active in the rotation.

This PR already includes code for a feature that was planned but is not yet possible using the web interface at the moment: multiple versions of the same rotation where the handoff time defines when a given version becomes active.

With this change, for the time being, the TimePeriod type itself fulfills no real purpose and the timeperiod entries are directly loaded as part of the schedule, bypassing the timeperiod loading code. However, there still is the plan to add standalone timeperiods in the future, thus the timeperiod code is kept.

More context for these changes:
- Icinga/icinga-notifications-web#177
- #193

The commits in this PR:
* 87a92b4d04a4bc5ffa9607646a6b3c86adeb4b59, 0fbbe5200608bcbcd28317601415eac28a713ebd: Some code improvements that prevent code duplication in following commits.
* 501ff1c6385061e175c7ba07a2ba35f0f279eb0b: Schema changes from #193 squashed into a single commit.
* b6f524ef7c929961f46ae0369c1a1a5cd993b0b8: I found the proposed upgrade script to be more complex and more destructive to my personal test data than necessary, thus I simplified it. Also, now it looks more in line with the other preexisting schema upgrades as well.
* 86d8e47d3d2e551be95f26e1c2cff3f044e7ead7: The main change of this PR, see general description above.
* 27c1180ed174ccc9323f704d1e440779e5539e43: Always explicitly call `Init()` on timeperiod entries and require this in other methods (as suggested in https://github.com/Icinga/icinga-notifications/pull/204#discussion_r1622606472).
* 83678ae29fd232e3cea79dc088910969f5ffc744: Add debug logging on how recipients were expanded and a warning if no contact was found like it may happen when a schedule has a gap (as suggested in https://github.com/Icinga/icinga-notifications/pull/204#pullrequestreview-2090414546).
* d47fde41171042dd9d7f096559d02eebabea15d1: Add a `/dump-schedules` debug endpoint that returns how all schedules expand within the next two days (as suggested in https://github.com/Icinga/icinga-notifications/pull/204#pullrequestreview-2090414546)

### Dependencies

To allow testing with Icinga Notifications Web, the following PRs are required there:

- https://github.com/Icinga/icinga-notifications-web/pull/183
- https://github.com/Icinga/ipl-html/pull/137
- https://github.com/Icinga/ipl-web/pull/222
- https://github.com/Icinga/ipl-web/pull/223

> [!CAUTION]
> Applying the schema upgrade is destructive to the current schedule configuration and there is no easy way to rollback. Be prepared for this and better create a backup first.

closes #193 (schema change already contained in this PR)