### PR TITLE
Channel default value by changing default logic

### DIFF
--- a/cmd/channels/email/main.go
+++ b/cmd/channels/email/main.go
@@ -95,7 +95,12 @@ func (ch *Email) Send(reversePath string, recipients []string, msg []byte) error
 }
 
 func (ch *Email) SetConfig(jsonStr json.RawMessage) error {
-	err := json.Unmarshal(jsonStr, ch)
+	err := plugin.PopulateDefaults(ch)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(jsonStr, ch)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %s %w", jsonStr, err)
 	}
@@ -108,24 +113,7 @@ func (ch *Email) SetConfig(jsonStr json.RawMessage) error {
 }
 
 func (ch *Email) GetInfo() *plugin.Info {
-	elements := []*plugin.ConfigOption{
-		{
-			Name: "sender_name",
-			Type: "string",
-			Label: map[string]string{
-				"en_US": "Sender Name",
-				"de_DE": "Absendername",
-			},
-		},
-		{
-			Name: "sender_mail",
-			Type: "string",
-			Label: map[string]string{
-				"en_US": "Sender Address",
-				"de_DE": "Absenderadresse",
-			},
-			Default: "icinga@example.com",
-		},
+	configAttrs := plugin.ConfigOptions{
 		{
 			Name:     "host",
 			Type:     "string",
@@ -145,6 +133,24 @@ func (ch *Email) GetInfo() *plugin.Info {
 			},
 			Min: types.Int{NullInt64: sql.NullInt64{Int64: 1, Valid: true}},
 			Max: types.Int{NullInt64: sql.NullInt64{Int64: 65535, Valid: true}},
+		},
+		{
+			Name: "sender_name",
+			Type: "string",
+			Label: map[string]string{
+				"en_US": "Sender Name",
+				"de_DE": "Absendername",
+			},
+			Default: "Icinga",
+		},
+		{
+			Name: "sender_mail",
+			Type: "string",
+			Label: map[string]string{
+				"en_US": "Sender Address",
+				"de_DE": "Absenderadresse",
+			},
+			Default: "icinga@example.com",
 		},
 		{
 			Name: "user",
@@ -176,11 +182,6 @@ func (ch *Email) GetInfo() *plugin.Info {
 				EncryptionTLS:      "TLS",
 			},
 		},
-	}
-
-	configAttrs, err := json.Marshal(elements)
-	if err != nil {
-		panic(err)
 	}
 
 	return &plugin.Info{

--- a/cmd/channels/email/main_test.go
+++ b/cmd/channels/email/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmail_SetConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonMsg string
+		want    *Email
+		wantErr bool
+	}{
+		{
+			name:    "empty-string",
+			jsonMsg: ``,
+			wantErr: true,
+		},
+		{
+			name:    "empty-json-obj-use-defaults",
+			jsonMsg: `{}`,
+			want:    &Email{SenderName: "Icinga", SenderMail: "icinga@example.com"},
+		},
+		{
+			name:    "sender-mail-null-equals-defaults",
+			jsonMsg: `{"sender_mail": null}`,
+			want:    &Email{SenderName: "Icinga", SenderMail: "icinga@example.com"},
+		},
+		{
+			name:    "sender-mail-overwrite",
+			jsonMsg: `{"sender_mail": "foo@bar"}`,
+			want:    &Email{SenderName: "Icinga", SenderMail: "foo@bar"},
+		},
+		{
+			name:    "sender-mail-overwrite-empty",
+			jsonMsg: `{"sender_mail": ""}`,
+			want:    &Email{SenderName: "Icinga", SenderMail: ""},
+		},
+		{
+			name:    "full-example-config",
+			jsonMsg: `{"sender_name":"icinga","sender_mail":"icinga@example.com","host":"smtp.example.com","port":"25","encryption":"none"}`,
+			want: &Email{
+				Host:       "smtp.example.com",
+				Port:       "25",
+				SenderName: "icinga",
+				SenderMail: "icinga@example.com",
+				User:       "",
+				Password:   "",
+				Encryption: "none",
+			},
+		},
+		{
+			name:    "user-but-missing-pass",
+			jsonMsg: `{"user": "foo"}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email := &Email{}
+			err := email.SetConfig(json.RawMessage(tt.jsonMsg))
+			assert.Equal(t, tt.wantErr, err != nil, "SetConfig() error = %v, wantErr = %t", err, tt.wantErr)
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, tt.want, email, "Email differs")
+		})
+	}
+}

--- a/cmd/channels/rocketchat/main.go
+++ b/cmd/channels/rocketchat/main.go
@@ -77,12 +77,16 @@ func (ch *RocketChat) SendNotification(req *plugin.NotificationRequest) error {
 }
 
 func (ch *RocketChat) SetConfig(jsonStr json.RawMessage) error {
+	err := plugin.PopulateDefaults(ch)
+	if err != nil {
+		return err
+	}
+
 	return json.Unmarshal(jsonStr, ch)
 }
 
 func (ch *RocketChat) GetInfo() *plugin.Info {
-
-	elements := []*plugin.ConfigOption{
+	configAttrs := plugin.ConfigOptions{
 		{
 			Name: "url",
 			Type: "string",
@@ -110,11 +114,6 @@ func (ch *RocketChat) GetInfo() *plugin.Info {
 			},
 			Required: true,
 		},
-	}
-
-	configAttrs, err := json.Marshal(elements)
-	if err != nil {
-		panic(err)
 	}
 
 	return &plugin.Info{

--- a/cmd/channels/webhook/main.go
+++ b/cmd/channels/webhook/main.go
@@ -27,7 +27,7 @@ type Webhook struct {
 }
 
 func (ch *Webhook) GetInfo() *plugin.Info {
-	elements := []*plugin.ConfigOption{
+	configAttrs := plugin.ConfigOptions{
 		{
 			Name: "method",
 			Type: "string",
@@ -65,7 +65,7 @@ func (ch *Webhook) GetInfo() *plugin.Info {
 				"en_US": "Go template applied to the current plugin.NotificationRequest to create an request body.",
 				"de_DE": "Go-Template über das zu verarbeitende plugin.NotificationRequest zum Erzeugen der mitgesendeten Anfragedaten.",
 			},
-			Default: `{{json .}}`,
+			Default: "{{json .}}",
 		},
 		{
 			Name: "response_status_codes",
@@ -82,11 +82,6 @@ func (ch *Webhook) GetInfo() *plugin.Info {
 		},
 	}
 
-	configAttrs, err := json.Marshal(elements)
-	if err != nil {
-		panic(err)
-	}
-
 	return &plugin.Info{
 		Name:             "Webhook",
 		Version:          internal.Version.Version,
@@ -96,7 +91,12 @@ func (ch *Webhook) GetInfo() *plugin.Info {
 }
 
 func (ch *Webhook) SetConfig(jsonStr json.RawMessage) error {
-	err := json.Unmarshal(jsonStr, ch)
+	err := plugin.PopulateDefaults(ch)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(jsonStr, ch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
    In a nutshell, the newly introduced plugin.PopulateDefaults function
    populates all fields of a Plugin-implementing struct with those fields
    from Info.ConfigAttributes where ConfigOption.Default is set. Thus, a
    single function call before parsing the user-submitted configuration
    within the Plugin.SetConfig method sets default values.

    As a result of the discussion between the Go and the Web team,
    summarized in #205, Web does not store key-value pairs to be omitted.

    Prior, an already JSON-encoded version of the ConfigOption slice was
    present in plugin.Info. Thus, this data wasn't easily available anymore.
    As the new code now needs to access this field, it was changed and a
    custom sql driver.Valuer was implemented for a slice type.

    While working on this, all ConfigOptions were put in the same order as
    the struct fields.

Requires <https://github.com/Icinga/icinga-notifications-web/pull/230>.

Closes #205.