### PR TITLE
icinga2: Check errors in HTTP status and JSON

### DIFF
--- a/internal/icinga2/api_responses_test.go
+++ b/internal/icinga2/api_responses_test.go
@@ -295,8 +295,33 @@ func TestApiResponseUnmarshal(t *testing.T) {
 		expected any
 	}{
 		{
+			name:     "empty",
+			jsonData: ``,
+			isError:  true,
+		},
+		{
 			name:     "invalid-json",
 			jsonData: `{":}"`,
+			isError:  true,
+		},
+		{
+			name:     "empty-json-struct",
+			jsonData: `{}`,
+			isError:  true,
+		},
+		{
+			name:     "error-field",
+			jsonData: `{"error":401,"status":"Unauthorized. Please check your user credentials."}`,
+			isError:  true,
+		},
+		{
+			name:     "error-field-with-valid-type",
+			jsonData: `{"type":"StateChange","error":401,"status":"Unauthorized. Please check your user credentials."}`,
+			isError:  true,
+		},
+		{
+			name:     "error-field-with-invalid-error",
+			jsonData: `{"error":"tja"}`,
 			isError:  true,
 		},
 		{

--- a/internal/icinga2/client_api_test.go
+++ b/internal/icinga2/client_api_test.go
@@ -1,0 +1,29 @@
+package icinga2
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestCheckHTTPResponseStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		status     string
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{"http-200", http.StatusOK, "200 OK", assert.NoError},
+		{"http-299", 299, "299 ???", assert.NoError},
+		{"http-204", http.StatusNoContent, "204 No Content", assert.NoError},
+		{"http-401", http.StatusUnauthorized, "401 Unauthorized", assert.Error},
+		{"http-500", http.StatusInternalServerError, "500 Internal Server Error", assert.Error},
+		{"http-900", 900, "900 ???", assert.Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, checkHTTPResponseStatusCode(tt.statusCode, tt.status))
+		})
+	}
+}


### PR DESCRIPTION
The Icinga 2 Event Stream connection did not validate the HTTP status code returned by the server. Consequently, HTTP errors were not identified and their error messages were incorrectly interpreted as valid messages. This occurred in two places: firstly, with regard to the HTTP status code, and secondly, in relation to the error field, which may be present within a JSON struct.

This modification introduces a brief HTTP status validation method that adheres to the specifications outlined in the Icinga 2 API documentation and advanced error checks in UnmarshalEventStreamResponse.