### PR TITLE
Refactor `browser_session` table

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -350,7 +350,7 @@ CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username citext NOT NULL,
     user_agent varchar(4096) NOT NULL,
-    authenticated_at bigint NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
+    authenticated_at bigint NOT NULL,
 
     CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id)
 );

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -349,10 +349,11 @@ COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by 
 CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username citext NOT NULL,
-    user_agent text NOT NULL,
+    user_agent varchar(4096) NOT NULL,
     authenticated_at bigint NOT NULL DEFAULT (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000),
 
-    CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id, username, user_agent)
+    CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id)
 );
 
-CREATE INDEX browser_session_authenticated_at_idx ON browser_session (authenticated_at);
+CREATE INDEX idx_browser_session_authenticated_at ON browser_session (authenticated_at DESC);
+CREATE INDEX idx_browser_session_username_agent ON browser_session (username, user_agent);

--- a/schema/pgsql/upgrades/029.sql
+++ b/schema/pgsql/upgrades/029.sql
@@ -9,5 +9,8 @@ ALTER TABLE browser_session
 ALTER TABLE browser_session
     ADD CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id);
 
+ALTER TABLE IF EXISTS browser_session
+    ALTER COLUMN authenticated_at DROP DEFAULT;
+
 CREATE INDEX idx_browser_session_authenticated_at ON browser_session (authenticated_at DESC);
 CREATE INDEX idx_browser_session_username_agent ON browser_session (username, user_agent);

--- a/schema/pgsql/upgrades/029.sql
+++ b/schema/pgsql/upgrades/029.sql
@@ -1,0 +1,13 @@
+ALTER TABLE browser_session
+    DROP CONSTRAINT pk_browser_session;
+
+DROP INDEX browser_session_authenticated_at_idx;
+
+ALTER TABLE browser_session
+    ALTER COLUMN user_agent TYPE varchar(4096) USING user_agent::varchar(4096);
+
+ALTER TABLE browser_session
+    ADD CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id);
+
+CREATE INDEX idx_browser_session_authenticated_at ON browser_session (authenticated_at DESC);
+CREATE INDEX idx_browser_session_username_agent ON browser_session (username, user_agent);


### PR DESCRIPTION
This PR modifies the `browser_session` table to reflect new changes to the data structure.

- The primary key no longer depends on the `username` or `user_agent`, as the session storage hook takes care of zombie entries before inserting new session data.
- Added the additional descending order to the existing `authenticated_at` index.
- Fixed index naming convention.
- A new combined index has been added, which speeds up lookups that use both `username` and `user_agent` conditions.
- The default expression for `authenticated_at` got removed, as the timestamp now gets supplied by the PHP daemon itself.

Fixes https://github.com/Icinga/icinga-notifications-web/issues/194
Fixes https://github.com/Icinga/icinga-notifications-web/issues/195