### PR TITLE
icinga2: Enhance debug logging

### DIFF
--- a/internal/icinga2/client_api.go
+++ b/internal/icinga2/client_api.go
@@ -255,7 +255,7 @@ func (client *Client) checkMissedChanges(ctx context.Context, objType string, ca
 
 		// Only process HARD states
 		if objQueriesResult.Attrs.StateType == StateTypeSoft {
-			client.Logger.Debugf("Skipping SOFT event, %#v", objQueriesResult.Attrs)
+			client.Logger.Debugw("Skipping SOFT event", zap.Inline(&objQueriesResult.Attrs))
 			continue
 		}
 
@@ -501,7 +501,7 @@ func (client *Client) listenEventStream() error {
 		case *StateChange:
 			// Only process HARD states
 			if respT.StateType == StateTypeSoft {
-				client.Logger.Debugf("Skipping SOFT State Change, %#v", respT)
+				client.Logger.Debugw("Skipping SOFT State Change", zap.Inline(respT))
 				continue
 			}
 
@@ -520,7 +520,8 @@ func (client *Client) listenEventStream() error {
 			if !respT.Downtime.IsFixed {
 				// This may never happen, but Icinga 2 does the same thing, and we need to ignore the start
 				// event for flexible downtime, as there will definitely be a triggered event for it.
-				client.Logger.Debugf("Skipping flexible downtime start event, %#v", respT)
+				client.Logger.Debugw("Skipping flexible downtime start event",
+					zap.Time("timestamp", respT.Timestamp.Time()), zap.Inline(&respT.Downtime))
 				continue
 			}
 
@@ -530,7 +531,8 @@ func (client *Client) listenEventStream() error {
 			if respT.Downtime.IsFixed {
 				// Fixed downtimes generate two events (start, triggered), the latter applies here and must
 				// be ignored, since we're going to process its start event to avoid duplicated notifications.
-				client.Logger.Debugf("Skipping fixed downtime triggered event, %#v", respT)
+				client.Logger.Debugw("Skipping fixed downtime triggered event",
+					zap.Time("timestamp", respT.Timestamp.Time()), zap.Inline(&respT.Downtime))
 				continue
 			}
 


### PR DESCRIPTION
This commit implements the `zapcore.ObjectMarshaler` interface for all API / event stream response result types that we currently sprintf the entire Object with `#%v` and allows us to lazily encode all necessary fields without bloating the debug logs with useless information.

**Example output:**
```bash
2024-06-14T16:10:47.521+0200	DEBUG	icinga2	Skipping SOFT event	{"source-id": 1, "name": "passive", "host": "docker-master", "state": 0, "state_type": 1, "in_downtime": false, "acknowledged": false, "last_state_change": "2024-06-14T15:05:22.434+0200", "groups": [], "check_result": {"exit_status": 0, "state": 0, "output": "This is passive check too"}}
2024-06-14T16:10:47.523+0200	DEBUG	icinga2	Skipping SOFT event	{"source-id": 1, "name": "ping4", "host": "DHCP-server", "state": 0, "state_type": 1, "in_downtime": false, "acknowledged": false, "last_state_change": "2024-06-14T15:05:43.319+0200", "groups": ["ping"], "check_result": {"exit_status": 0, "state": 0, "output": "PING OK - Packet loss = 0%, RTA = 0.82 ms"}}
2024-06-14T16:10:47.527+0200	DEBUG	icinga2	Stopped processing event with superfluous state change	{"source-id": 1, "event": "[time=2024-06-14 16:10:47.523099 +0200 CEST m=+0.168237293 type=\"state\" severity=ok]", "error": "ignoring superfluous state change: ok state event from source 1"}
2024-06-14T16:10:47.527+0200	DEBUG	icinga2	Skipping SOFT event	{"source-id": 1, "name": "random fortune", "host": "DHCP-server", "state": 0, "state_type": 1, "in_downtime": false, "acknowledged": false, "last_state_change": "2024-06-14T15:05:30.854+0200", "groups": ["app-db", "department-nms", "env-acceptance", "location-berlin"], "check_result": {"exit_status": 0, "state": 0, "output": "Your temporary financial embarrassment will be relieved in a surprising manner."}}
```