### PR TITLE
doc/01-About.md: Remove relative link outside doc

### DIFF
--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -53,4 +53,4 @@ To install Icinga Notifications see [Installation](02-Installation.md).
 ## License
 
 Icinga Notifications and the Icinga Notifications documentation are licensed under the terms of the
-[GNU General Public License Version 2](../LICENSE).
+[GNU General Public License Version 2](https://github.com/Icinga/icinga-notifications/blob/main/LICENSE).


### PR DESCRIPTION
First, relative links outside the `doc` directory are possible and work. However, the main page can be accessed via `…/` or `…/doc/01-About.md`. While a relative link works for the second, it breaks for the first.

For the docs, this link now points to the LICENSE file on GitHub.

Reported-by: Noé Costa <https://github.com/Icinga/icinga-notifications/pull/210#issuecomment-2211076354>