### PR TITLE
Ignore flapping state if flapping detection isn't enabled

### DIFF
--- a/internal/icinga2/api_responses.go
+++ b/internal/icinga2/api_responses.go
@@ -161,6 +161,7 @@ type HostServiceRuntimeAttributes struct {
 	Acknowledgement           int         `json:"acknowledgement"`
 	IsFlapping                bool        `json:"flapping"`
 	AcknowledgementLastChange UnixFloat   `json:"acknowledgement_last_change"`
+	EnableFlapping            bool        `json:"enable_flapping"`
 }
 
 // MarshalLogObject implements the zapcore.ObjectMarshaler interface.
@@ -350,6 +351,14 @@ type ObjectCreatedDeleted struct {
 	ObjectName string `json:"object_name"`
 	ObjectType string `json:"object_type"`
 	EventType  string `json:"type"`
+}
+
+// IcingaApplication represents the Icinga 2 API status endpoint query result of type IcingaApplication.
+// https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#status-and-statistics
+type IcingaApplication struct {
+	App struct {
+		EnableFlapping bool `json:"enable_flapping"`
+	} `json:"app"`
 }
 
 // UnmarshalEventStreamResponse unmarshal a JSON response line from the Icinga 2 API Event Stream.

--- a/internal/icinga2/client.go
+++ b/internal/icinga2/client.go
@@ -265,7 +265,9 @@ func (client *Client) buildAcknowledgementEvent(ctx context.Context, ack *Acknow
 		if err != nil {
 			return nil, err
 		}
-		if !isMuted(queryResult) {
+		if muted, err := isMuted(ctx, client, queryResult); err != nil {
+			return nil, err
+		} else if !muted {
 			ev.Message = queryResult.Attrs.LastCheckResult.Output
 			ev.SetMute(false, "Acknowledgement cleared")
 		}
@@ -310,7 +312,9 @@ func (client *Client) buildDowntimeEvent(ctx context.Context, d Downtime, startE
 		if err != nil {
 			return nil, err
 		}
-		if !isMuted(queryResult) {
+		if muted, err := isMuted(ctx, client, queryResult); err != nil {
+			return nil, err
+		} else if !muted {
 			// When a downtime is cancelled/expired and there's no other active downtime/ack, we're going to send some
 			// notifications if there's still an active incident. Therefore, we need the most recent CheckResult of
 			// that Checkable to use it for the notifications.
@@ -347,7 +351,9 @@ func (client *Client) buildFlappingEvent(ctx context.Context, flapping *Flapping
 		if err != nil {
 			return nil, err
 		}
-		if !isMuted(queryResult) {
+		if muted, err := isMuted(ctx, client, queryResult); err != nil {
+			return nil, err
+		} else if !muted {
 			ev.Message = queryResult.Attrs.LastCheckResult.Output
 			ev.SetMute(false, reason)
 		}


### PR DESCRIPTION
The Icinga 2 Checkable `flapping` runtime attribute is always updated even when flapping detection is disabled and leads to false positives, causing Icinga Notifications to falsely suppress an incident. To prevent this, this PR additionally checks for the `enable_flapping` attribute of a checkable and globally for the `IcingaApplication` type.

And YES, I can safely use `app` as a json key because of this.
```bash
[2024-07-08 11:20:18 +0200] critical/config: Error: Validation failed for object 'my-app' of type 'IcingaApplication'; Attribute 'name': Application object must be named 'app'.
Location: in /Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/features-enabled/app.conf: 1:0-1:32
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/features-enabled/app.conf(1): object IcingaApplication "my-app" {}
                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/features-enabled/app.conf(2): 
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/features-enabled/app.conf(3):
```