### PR TITLE
Add AUTHORS and .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+<sukhwinder.dhillon@icinga.com> <sukhwinder33445@gmail.com>
+Alexander A. Klimov <alexander.klimov@icinga.com> <alexander.klimov@icinga.com>
+Ravi Kumar Kempapura Srinivasa <ravi.srinivasa@icinga.com> <33730024+raviks789@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+Alexander A. Klimov <alexander.klimov@icinga.com>
+Alvar Penning <alvar.penning@icinga.com>
+Johannes Meyer <johannes.meyer@icinga.com>
+Julian Brost <julian.brost@icinga.com>
+Noé Costa <noe.costa@icinga.com>
+Ravi Kumar Kempapura Srinivasa <ravi.srinivasa@icinga.com>
+Sukhwinder Dhillon <sukhwinder.dhillon@icinga.com>
+Yonas Habteab <yonas.habteab@icinga.com>


### PR DESCRIPTION
Generated using:

```sh
git log --format='format:%aN <%aE>' | grep -vFx 'dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>' | sort -u > AUTHORS
```

@Al2Klimov @raviks789 I've made the (non-)abbreviation of your names consistent with the [Icinga DB `AUTHORS` file](https://github.com/Icinga/icingadb/blob/main/AUTHORS), please let me know if you prefer something different.