### PR TITLE
Schema: don't limit browser_session.user_agent to 4096 chars

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -448,7 +448,7 @@ CREATE INDEX idx_incident_history_time_type ON incident_history(time, type) COMM
 CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username varchar(254) NOT NULL COLLATE utf8mb4_unicode_ci,
-    user_agent varchar(4096) NOT NULL,
+    user_agent text NOT NULL,
     authenticated_at bigint NOT NULL,
 
     CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id)

--- a/schema/mysql/upgrades/035.sql
+++ b/schema/mysql/upgrades/035.sql
@@ -1,0 +1,1 @@
+ALTER TABLE browser_session MODIFY COLUMN user_agent text NOT NULL;

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -493,7 +493,7 @@ COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by 
 CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username citext NOT NULL,
-    user_agent varchar(4096) NOT NULL,
+    user_agent text NOT NULL,
     authenticated_at bigint NOT NULL,
 
     CONSTRAINT pk_browser_session PRIMARY KEY (php_session_id),

--- a/schema/pgsql/upgrades/035.sql
+++ b/schema/pgsql/upgrades/035.sql
@@ -1,0 +1,1 @@
+ALTER TABLE browser_session ALTER COLUMN user_agent TYPE text;


### PR DESCRIPTION
* This isn't necessary anymore due to https://github.com/Icinga/icinga-notifications/pull/203#discussion_r1643021910
* No web changes are necessary
* Fresh and upgraded schema don't differ