### PR TITLE
Channels: Rework default ConfigOptions and reorder methods

### DIFF
--- a/cmd/channels/email/main.go
+++ b/cmd/channels/email/main.go
@@ -115,24 +115,24 @@ func (ch *Email) SetConfig(jsonStr json.RawMessage) error {
 func (ch *Email) GetInfo() *plugin.Info {
 	configAttrs := plugin.ConfigOptions{
 		{
-			Name:     "host",
-			Type:     "string",
-			Required: true,
+			Name: "host",
+			Type: "string",
 			Label: map[string]string{
 				"en_US": "SMTP Host",
 				"de_DE": "SMTP Host",
 			},
+			Required: true,
 		},
 		{
-			Name:     "port",
-			Type:     "number",
-			Required: true,
+			Name: "port",
+			Type: "number",
 			Label: map[string]string{
 				"en_US": "SMTP Port",
 				"de_DE": "SMTP Port",
 			},
-			Min: types.Int{NullInt64: sql.NullInt64{Int64: 1, Valid: true}},
-			Max: types.Int{NullInt64: sql.NullInt64{Int64: 65535, Valid: true}},
+			Required: true,
+			Min:      types.Int{NullInt64: sql.NullInt64{Int64: 1, Valid: true}},
+			Max:      types.Int{NullInt64: sql.NullInt64{Int64: 65535, Valid: true}},
 		},
 		{
 			Name: "sender_name",
@@ -141,7 +141,8 @@ func (ch *Email) GetInfo() *plugin.Info {
 				"en_US": "Sender Name",
 				"de_DE": "Absendername",
 			},
-			Default: "Icinga",
+			Default:  "Icinga",
+			Required: true,
 		},
 		{
 			Name: "sender_mail",
@@ -150,7 +151,7 @@ func (ch *Email) GetInfo() *plugin.Info {
 				"en_US": "Sender Address",
 				"de_DE": "Absenderadresse",
 			},
-			Default: "icinga@example.com",
+			Required: true,
 		},
 		{
 			Name: "user",
@@ -158,6 +159,10 @@ func (ch *Email) GetInfo() *plugin.Info {
 			Label: map[string]string{
 				"en_US": "SMTP User",
 				"de_DE": "SMTP Benutzer",
+			},
+			Help: map[string]string{
+				"en_US": "When configuring an SMTP user, an SMTP password must also be set.",
+				"de_DE": "Das Setzen eines SMTP Benutzers erfordert ebenfalls ein SMTP Passwort.",
 			},
 		},
 		{

--- a/cmd/channels/email/main_test.go
+++ b/cmd/channels/email/main_test.go
@@ -21,12 +21,12 @@ func TestEmail_SetConfig(t *testing.T) {
 		{
 			name:    "empty-json-obj-use-defaults",
 			jsonMsg: `{}`,
-			want:    &Email{SenderName: "Icinga", SenderMail: "icinga@example.com"},
+			want:    &Email{SenderName: "Icinga"},
 		},
 		{
 			name:    "sender-mail-null-equals-defaults",
 			jsonMsg: `{"sender_mail": null}`,
-			want:    &Email{SenderName: "Icinga", SenderMail: "icinga@example.com"},
+			want:    &Email{SenderName: "Icinga"},
 		},
 		{
 			name:    "sender-mail-overwrite",

--- a/cmd/channels/rocketchat/main.go
+++ b/cmd/channels/rocketchat/main.go
@@ -11,14 +11,62 @@ import (
 	"time"
 )
 
+func main() {
+	plugin.RunPlugin(&RocketChat{})
+}
+
 type RocketChat struct {
 	URL    string `json:"url"`
 	UserID string `json:"user_id"`
 	Token  string `json:"token"`
 }
 
-func main() {
-	plugin.RunPlugin(&RocketChat{})
+func (ch *RocketChat) GetInfo() *plugin.Info {
+	configAttrs := plugin.ConfigOptions{
+		{
+			Name: "url",
+			Type: "string",
+			Label: map[string]string{
+				"en_US": "Rocket.Chat URL",
+				"de_DE": "Rocket.Chat URL",
+			},
+			Required: true,
+		},
+		{
+			Name: "user_id",
+			Type: "string",
+			Label: map[string]string{
+				"en_US": "User ID",
+				"de_DE": "Benutzer ID",
+			},
+			Required: true,
+		},
+		{
+			Name: "token",
+			Type: "secret",
+			Label: map[string]string{
+				"en_US": "Personal Access Token",
+				"de_DE": "Persönliches Zugangstoken",
+			},
+			Required: true,
+		},
+	}
+
+	return &plugin.Info{
+		Name:             "Rocket.Chat",
+		Version:          internal.Version.Version,
+		Author:           "Icinga GmbH",
+		ConfigAttributes: configAttrs,
+	}
+}
+
+func (ch *RocketChat) SetConfig(jsonStr json.RawMessage) error {
+	err := plugin.PopulateDefaults(ch)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonStr, ch)
 }
 
 func (ch *RocketChat) SendNotification(req *plugin.NotificationRequest) error {
@@ -74,52 +122,4 @@ func (ch *RocketChat) SendNotification(req *plugin.NotificationRequest) error {
 	}
 
 	return nil
-}
-
-func (ch *RocketChat) SetConfig(jsonStr json.RawMessage) error {
-	err := plugin.PopulateDefaults(ch)
-	if err != nil {
-		return err
-	}
-
-	return json.Unmarshal(jsonStr, ch)
-}
-
-func (ch *RocketChat) GetInfo() *plugin.Info {
-	configAttrs := plugin.ConfigOptions{
-		{
-			Name: "url",
-			Type: "string",
-			Label: map[string]string{
-				"en_US": "Rocket.Chat URL",
-				"de_DE": "Rocket.Chat URL",
-			},
-			Required: true,
-		},
-		{
-			Name: "user_id",
-			Type: "string",
-			Label: map[string]string{
-				"en_US": "User ID",
-				"de_DE": "Benutzer ID",
-			},
-			Required: true,
-		},
-		{
-			Name: "token",
-			Type: "secret",
-			Label: map[string]string{
-				"en_US": "Personal Access Token",
-				"de_DE": "Persönliches Zugangstoken",
-			},
-			Required: true,
-		},
-	}
-
-	return &plugin.Info{
-		Name:             "Rocket.Chat",
-		Version:          internal.Version.Version,
-		Author:           "Icinga GmbH",
-		ConfigAttributes: configAttrs,
-	}
 }

--- a/cmd/channels/webhook/main.go
+++ b/cmd/channels/webhook/main.go
@@ -39,7 +39,8 @@ func (ch *Webhook) GetInfo() *plugin.Info {
 				"en_US": "HTTP request method used for the web request.",
 				"de_DE": "HTTP-Methode für die Anfrage.",
 			},
-			Default: "POST",
+			Default:  "POST",
+			Required: true,
 		},
 		{
 			Name: "url_template",
@@ -78,7 +79,8 @@ func (ch *Webhook) GetInfo() *plugin.Info {
 				"en_US": "Comma separated list of expected HTTP response status code, e.g., 200,201,202,208,418",
 				"de_DE": "Kommaseparierte Liste erwarteter Status-Code der HTTP-Antwort, z.B.: 200,201,202,208,418",
 			},
-			Default: "200",
+			Default:  "200",
+			Required: true,
 		},
 	}
 

--- a/cmd/channels/webhook/main.go
+++ b/cmd/channels/webhook/main.go
@@ -14,6 +14,10 @@ import (
 	"text/template"
 )
 
+func main() {
+	plugin.RunPlugin(&Webhook{})
+}
+
 type Webhook struct {
 	Method              string `json:"method"`
 	URLTemplate         string `json:"url_template"`
@@ -163,8 +167,4 @@ func (ch *Webhook) SendNotification(req *plugin.NotificationRequest) error {
 	}
 
 	return nil
-}
-
-func main() {
-	plugin.RunPlugin(&Webhook{})
 }


### PR DESCRIPTION
    channels: Mark Required ConfigOptions

    Each plugin.ConfigOption was revisited and potentially being marked as
    Required, which was missing at some. Furthermore, the order of the
    fields was changed to match the struct field order of ConfigOption.


    channels: Reorder methods according to plugin.Plugin

    The plugin.Plugin interface specifies the three methods required for the
    channel plugin RPC API in their logical order. Considering that these
    channels are the blueprint for external channel development, the order
    of implementing channel plugins was changed to correspond to the
    interface.

    For all files, the main function has been moved to the top.

    In addition, the Email.Send method received a documentation string
    indicating that it implements the enmime.Sender interface, as it is not
    directly called anywhere. Further, the Email.GetServer method got
    inlined as it was only called from one other method.

Closes #240.