### PR TITLE
Fix warnings during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Icinga Notifications | (c) 2023 Icinga GmbH | GPLv2+
 
-FROM docker.io/library/golang as build
-ENV CGO_ENABLED 0
+FROM docker.io/library/golang AS build
+ENV CGO_ENABLED=0
 COPY . /src/icinga-notifications
 WORKDIR /src/icinga-notifications
 


### PR DESCRIPTION
Building the container image started showing the following two warning for me recently which are addressed by this commit:

```
2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
```