### PR TITLE
Docker GHA: Upload Docker images on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,41 @@ name: Docker
 on:
   push:
     branches: [ main ]
-  pull_request: {}
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Build Image
+
+    - uses: docker/metadata-action@v5
+      id: meta
+      with:
+        images: |
+          icinga/icinga-notifications
+        tags: |
+          type=ref,event=branch,enable={{is_default_branch}}
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+
+    - uses: docker/setup-qemu-action@v3
+
+    - uses: docker/setup-buildx-action@v3
+
+    - if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
       uses: docker/build-push-action@v6
+      with:
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
With this change, the Docker GitHub Action now creates multi-platform Docker images on releases and pushes those to Docker Hub. The changes were both inspired by the Docker defaults and <https://github.com/Icinga/icinga-kubernetes/blob/main/.github/workflows/docker-image.yml>.

Note: I am unable to check if the necessary environment variables are already set in this repository. This needs to be done by somebody with the sufficient privileges first. Furthermore, there is no project on Docker Hub so far, maybe it needs to be created first.