### PR TITLE
cmd/icinga-notifications: Fix SYSLOG_IDENTIFIER for zap fields in journald

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -23,7 +23,7 @@ func main() {
 	daemon.ParseFlagsAndConfig()
 	conf := daemon.Config()
 
-	logs, err := logging.NewLoggingFromConfig("icinga-notifications", conf.Logging)
+	logs, err := logging.NewLoggingFromConfig("notifications", conf.Logging)
 	if err != nil {
 		utils.PrintErrorThenExit(err, daemon.ExitFailure)
 	}


### PR DESCRIPTION
One line diff with a bit of history ahead.

When logging into "systemd-journald", the journaldCore type will be used. Eventually, a log event will be written, resulting in *journaldCore.Write() to be called. There, the name, now called identifier, will be set as the "SYSLOG_IDENTIFIER" field.

This is now passed down to journald, where the "SYSLOG_IDENTIFIER" is handled as the "[s]yslog compatibility fields containing […] the identifier string (i.e. "tag")"[^0]. After some digging, I found a specification of this tag in RFC 3164, stating that a "TAG is a string of ABNF alphanumeric characters that MUST NOT exceed 32 characters"[^1].

As it turns out, "icinga-notifications" does not match this specification due to the presence of "-". When removing it, suddenly journalctl shows the fields prefixed with "ICINGANOTIFICATIONS_".

However, as this looks like a typo and someone is going to "fix" it in the future, I decided to truncate the tag (a.k.a. identifier a.k.a. name) to be only "notifications". Now, an error might look like "NOTIFICATIONS_ERROR".

[^0]: https://www.freedesktop.org/software/systemd/man/latest/systemd.journal-fields.html#SYSLOG_FACILITY=
[^1]: https://datatracker.ietf.org/doc/html/rfc3164#section-4.1.3