### PR TITLE
Container images: show git commit hash in --version output when built on GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,3 +39,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
+        # Keep the .git to allow including the commit in the --version output, see also:
+        # https://docs.docker.com/build/building/context/#keep-git-directory
+        build-args: |
+          BUILDKIT_CONTEXT_KEEP_GIT_DIR=1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,8 +12,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-
     - uses: docker/metadata-action@v5
       id: meta
       with:


### PR DESCRIPTION
By default, BuildKit checks out the git repository but does not include the `.git` directory in the build context. This then prevents `go build` from embedding the commit hash into the binary which we want to include in the `--version` output. This behavior can be changed by setting a build argument and fixes our `--version` output.

This also implies that the use of `actions/checkout` was actually redundant and I've removed it in a separate commit.

The changes to the `Dockerfile` (b7281ce14b56343515ccaf8810c10d700f887328) are intended to demonstrate that this actually fixes the issue. After an initial review, I'd remove that commit, wait for a final approval and then merge it.

fixes #257