### PR TITLE
webhook: Basic TLS Configuration, Custom Headers

### DIFF
--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBool_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		out     Bool
+		wantErr bool
+	}{
+		{"bool-true", `true`, true, false},
+		{"bool-false", `false`, false, false},
+		{"string-true", `"y"`, true, false},
+		{"string-false", `"n"`, false, false},
+		{"string-invalid", `"NEIN"`, false, true},
+		{"invalid-type", `23`, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out Bool
+			if err := out.UnmarshalJSON([]byte(tt.in)); tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.out, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change allows some basic TLS related configuration changes:
- Fixed Certificate Common Name
- Custom CA
- Insecure Mode w/o any verification

The last setting brought me to an unexpected boolean representation in the JSON configuration, requiring a custom boolean type. It was added to pkg/plugin and its documentation.

In addition, support for arbitrary HTTP request headers was added. This allows custom headers, even carrying values based on the NotificationRequest.

Additionally, an unique User-Agent was assigned.

Closes #256.