### PR TITLE
doc: Bump MySQL/MariaDB version for JSON_OBJECTAGG

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -21,7 +21,7 @@ or install [from source](02-Installation.md.d/From-Source.md).
 
 ## Setting up the Database
 
-A MySQL (≥5.7.9), MariaDB (≥10.2.2), or PostgreSQL (≥9.6) database is required to run Icinga Notifications.
+A MySQL (≥5.7.22), MariaDB (≥10.5.0), or PostgreSQL (≥9.6) database is required to run Icinga Notifications.
 Please follow the steps listed for your target database,
 which guide you through setting up the database and user and importing the schema.
 


### PR DESCRIPTION
There was a bug report in the Icinga Community Forum[^0] regarding an unknown SQL function when using MariaDB 10.3.39. The function in question was `JSON_OBJECTAGG`, only being used in one place by web[^1].

MariaDB's documentation states that this function was introduced in version 10.5.0[^2], greater than the currently documented infimum. This fixes our docs.

MySQL has introduced this function in version 5.7.22[^3] and its required version was incremented as well.

This function's counterpart in PostgreSQL, `json_object_agg`, is available in the required versions[^4].

[^0]: https://community.icinga.com/t/current-state-of-icinga-notifications-modules/14666
[^1]: https://github.com/Icinga/icinga-notifications-web/blob/ede7734436ddee952f89295932fbc05e0b4af6e7/library/Notifications/Model/Behavior/IdTagAggregator.php#L58-L59
[^2]: https://mariadb.com/kb/en/json_objectagg/
[^3]: https://dev.mysql.com/doc/refman/5.7/en/aggregate-functions.html#function_json-objectagg
[^4]: https://www.postgresql.org/docs/9.6/functions-aggregate.html
