### PR TITLE
golangci-lint: Address issues and config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,9 +24,7 @@ jobs:
     - name: Vet
       run: go vet ./...
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: latest
-        # Enable the gosec linter w/o having to create a .golangci.yml config
-        args: -E gosec
         skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+
+linters:
+  default: standard
+
+  enable:
+    - bidichk # dangerous Unicode chars
+    - bodyclose # HTTP response body is closed
+    - exptostd # functions from golang.org/x/exp/ that can be replaced by std functions
+    - forcetypeassert # forced type assertions
+    - gosec # security problems
+    - loggercheck # key value pairs for common logger libraries (including zap)
+    - misspell # commonly misspelled English words
+    - nosprintfhostport # misuse of Sprintf to construct a host with port in a URL
+    - rowserrcheck # Rows.Err of rows is checked
+    - sqlclosecheck # sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed
+
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - '-ST1000' # ignore missing package comments
+        - '-ST1003' # ignore capitalization in camel case names

--- a/cmd/channels/rocketchat/main.go
+++ b/cmd/channels/rocketchat/main.go
@@ -115,7 +115,7 @@ func (ch *RocketChat) SendNotification(req *plugin.NotificationRequest) error {
 		return fmt.Errorf("error while sending http request to rocketchat server: %w", err)
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.New(resp.Status)

--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Cannot create database connection from config: %+v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/internal/channel/plugin.go
+++ b/internal/channel/plugin.go
@@ -35,7 +35,7 @@ func NewPlugin(pluginType string, logger *zap.SugaredLogger) (*Plugin, error) {
 
 	logger.Debugw("Starting new channel plugin process", zap.String("path", file))
 
-	cmd := exec.Command(file)
+	cmd := exec.Command(file) //#nosec G204 -- plugins are launched from dynamic paths
 
 	started := false
 	var childIOPipes []io.Closer

--- a/internal/config/verify.go
+++ b/internal/config/verify.go
@@ -121,16 +121,16 @@ func (r *RuntimeConfig) debugVerifyContact(id int64, contact *recipient.Contact)
 
 	for i, address := range contact.Addresses {
 		if address == nil {
-			return fmt.Errorf("Addresses[%d] is nil", i)
+			return fmt.Errorf("contact.Addresses[%d] is nil", i)
 		}
 
 		if address.ContactID != id {
-			return fmt.Errorf("Addresses[%d] has ContactID = %d instead of %d", i, address.ContactID, id)
+			return fmt.Errorf("contact.Addresses[%d] has ContactID = %d instead of %d", i, address.ContactID, id)
 		}
 
 		err := r.debugVerifyContactAddress(address.ID, address)
 		if err != nil {
-			return fmt.Errorf("Addresses[%d]: %w", i, err)
+			return fmt.Errorf("contact.Addresses[%d]: %w", i, err)
 		}
 	}
 
@@ -160,12 +160,12 @@ func (r *RuntimeConfig) debugVerifyGroup(id int64, group *recipient.Group) error
 
 	for i, member := range group.Members {
 		if member == nil {
-			return fmt.Errorf("Members[%d] is nil", i)
+			return fmt.Errorf("group.Members[%d] is nil", i)
 		}
 
 		err := r.debugVerifyContact(member.ID, member)
 		if err != nil {
-			return fmt.Errorf("Members[%d]: %w", i, err)
+			return fmt.Errorf("group.Members[%d]: %w", i, err)
 		}
 	}
 
@@ -183,7 +183,7 @@ func (r *RuntimeConfig) debugVerifyTimePeriod(id int64, period *timeperiod.TimeP
 
 	for i, entry := range period.Entries {
 		if entry == nil {
-			return fmt.Errorf("Entries[%d] is nil", i)
+			return fmt.Errorf("period.Entries[%d] is nil", i)
 		}
 	}
 
@@ -201,25 +201,25 @@ func (r *RuntimeConfig) debugVerifySchedule(id int64, schedule *recipient.Schedu
 
 	for i, rotation := range schedule.Rotations {
 		if rotation == nil {
-			return fmt.Errorf("Rotations[%d] is nil", i)
+			return fmt.Errorf("schedule.Rotations[%d] is nil", i)
 		}
 
 		for j, member := range rotation.Members {
 			if member == nil {
-				return fmt.Errorf("Rotations[%d].Members[%d] is nil", i, j)
+				return fmt.Errorf("schedule.Rotations[%d].Members[%d] is nil", i, j)
 			}
 
 			if member.Contact != nil {
 				err := r.debugVerifyContact(member.ContactID.Int64, member.Contact)
 				if err != nil {
-					return fmt.Errorf("Contact: %w", err)
+					return fmt.Errorf("schedule.Rotations[%d].Members[%d].Contact: %w", i, j, err)
 				}
 			}
 
 			if member.ContactGroup != nil {
 				err := r.debugVerifyGroup(member.ContactGroupID.Int64, member.ContactGroup)
 				if err != nil {
-					return fmt.Errorf("ContactGroup: %w", err)
+					return fmt.Errorf("schedule.Rotations[%d].Members[%d].ContactGroup: %w", i, j, err)
 				}
 			}
 		}
@@ -254,68 +254,68 @@ func (r *RuntimeConfig) debugVerifyRule(id int64, rule *rule.Rule) error {
 
 	for escalationID, escalation := range rule.Escalations {
 		if escalation == nil {
-			return fmt.Errorf("Escalations[%d] is nil", escalationID)
+			return fmt.Errorf("rule.Escalations[%d] is nil", escalationID)
 		}
 
 		if escalation.ID != escalationID {
-			return fmt.Errorf("Escalations[%d]: ecalation has ID %d but is referenced as %d",
+			return fmt.Errorf("rule.Escalations[%d]: ecalation has ID %d but is referenced as %d",
 				escalationID, escalation.ID, escalationID)
 		}
 
 		if escalation.RuleID != rule.ID {
-			return fmt.Errorf("Escalations[%d] (ID=%d) has RuleID = %d while being referenced from rule %d",
+			return fmt.Errorf("rule.Escalations[%d] (ID=%d) has RuleID = %d while being referenced from rule %d",
 				escalationID, escalation.ID, escalation.RuleID, rule.ID)
 		}
 
 		if escalation.ConditionExpr.Valid && escalation.Condition == nil {
-			return fmt.Errorf("Escalations[%d] (ID=%d) has ConditionExpr but Condition is nil", escalationID, escalation.ID)
+			return fmt.Errorf("rule.Escalations[%d] (ID=%d) has ConditionExpr but Condition is nil", escalationID, escalation.ID)
 		}
 
 		// TODO: verify fallback
 
 		for i, escalationRecpient := range escalation.Recipients {
 			if escalationRecpient == nil {
-				return fmt.Errorf("Escalations[%d].Recipients[%d] is nil", escalationID, i)
+				return fmt.Errorf("rule.Escalations[%d].Recipients[%d] is nil", escalationID, i)
 			}
 
 			if escalationRecpient.EscalationID != escalation.ID {
-				return fmt.Errorf("Escalation[%d].Recipients[%d].EscalationID = %d does not match Escalations[%d].ID = %d",
+				return fmt.Errorf("rule.Escalation[%d].Recipients[%d].EscalationID = %d does not match Escalations[%d].ID = %d",
 					escalationID, i, escalationRecpient.EscalationID, escalationID, escalation.ID)
 			}
 
 			switch rec := escalationRecpient.Recipient.(type) {
 			case *recipient.Contact:
 				if rec == nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Contact) is nil", escalationID, i)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Contact) is nil", escalationID, i)
 				}
 
 				err := r.debugVerifyContact(escalationRecpient.ContactID.Int64, rec)
 				if err != nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Contact): %w", escalationID, i, err)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Contact): %w", escalationID, i, err)
 				}
 
 			case *recipient.Group:
 				if rec == nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Group) is nil", escalationID, i)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Group) is nil", escalationID, i)
 				}
 
 				err := r.debugVerifyGroup(escalationRecpient.GroupID.Int64, rec)
 				if err != nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Group): %w", escalationID, i, err)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Group): %w", escalationID, i, err)
 				}
 
 			case *recipient.Schedule:
 				if rec == nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Schedule) is nil", escalationID, i)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Schedule) is nil", escalationID, i)
 				}
 
 				err := r.debugVerifySchedule(escalationRecpient.ScheduleID.Int64, rec)
 				if err != nil {
-					return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient (Schedule): %w", escalationID, i, err)
+					return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient (Schedule): %w", escalationID, i, err)
 				}
 
 			default:
-				return fmt.Errorf("Escalations[%d].Recipients[%d].Recipient has invalid type %T", escalationID, i, rec)
+				return fmt.Errorf("rule.Escalations[%d].Recipients[%d].Recipient has invalid type %T", escalationID, i, rec)
 			}
 		}
 	}

--- a/internal/icinga2/client.go
+++ b/internal/icinga2/client.go
@@ -505,7 +505,7 @@ func (client *Client) worker() {
 		case catchupMsg, ok := <-catchupEventCh:
 			// Process an incoming event
 			if ok && catchupMsg.error == nil {
-				client.CallbackFn(catchupMsg.eventMsg.event)
+				client.CallbackFn(catchupMsg.event)
 				catchupCacheUpdate(catchupMsg.eventMsg)
 				break
 			}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -245,16 +245,16 @@ func (l *Listener) DumpSchedules(w http.ResponseWriter, r *http.Request) {
 	defer l.runtimeConfig.RUnlock()
 
 	for _, schedule := range l.runtimeConfig.Schedules {
-		fmt.Fprintf(w, "[id=%d] %q:\n", schedule.ID, schedule.Name)
+		_, _ = fmt.Fprintf(w, "[id=%d] %q:\n", schedule.ID, schedule.Name)
 
 		// Iterate in 30 minute steps as this is the granularity Icinga Notifications Web allows in the configuration.
 		// Truncation to seconds happens only for a more readable output.
 		step := 30 * time.Minute
 		start := time.Now().Truncate(time.Second)
 		for t := start; t.Before(start.Add(48 * time.Hour)); t = t.Add(step) {
-			fmt.Fprintf(w, "\t%v: %v\n", t, schedule.GetContactsAt(t))
+			_, _ = fmt.Fprintf(w, "\t%v: %v\n", t, schedule.GetContactsAt(t))
 		}
 
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 	}
 }

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -265,9 +265,15 @@ func (o *Object) EvalExists(key string) bool {
 	return ok
 }
 
+// ID generates a stable identifier based on a source ID and tags.
+//
 // TODO: the return value of this function must be stable like forever
 func ID(source int64, tags map[string]string) types.Binary {
 	h := sha256.New()
+
+	if source < 0 {
+		panic(fmt.Sprintf("source value %d is negative", source))
+	}
 
 	sourceBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(sourceBytes, uint64(source))


### PR DESCRIPTION
Within the last months, some of the linters used by golangci-lint started detecting more issues, resulting in reports for Icinga Notifications. Some errors were addressed, others marked as false positives, and a .golangci.yml configuration was created with a list of additional linters selected by trusting my gut.

---

Fixes #289.