### PR TITLE
Make unit tests compile on 32 bit

### DIFF
--- a/internal/object/objects_test.go
+++ b/internal/object/objects_test.go
@@ -23,7 +23,7 @@ func TestRestoreMutedObjects(t *testing.T) {
 		args := map[string]any{
 			"type":       "notifications",
 			"name":       "Icinga Notifications",
-			"changed_at": 1720702049000,
+			"changed_at": int64(1720702049000),
 		}
 		// We can't use config.Source here unfortunately due to cyclic import error!
 		id, err := utils.InsertAndFetchId(ctx, tx, `INSERT INTO source (type, name, changed_at) VALUES (:type, :name, :changed_at)`, args)


### PR DESCRIPTION
any(1720702049000) is an int which only has 32 bits on 32 bit and overflows at compile time. An int64 doesn't.

This PR repairs our pipelines.

## Test

`docker run --rm -itv "$(pwd):/icinga-notifications" -w /icinga-notifications --platform linux/386 golang go test ./...`

### Before

https://git.icinga.com/packages/icinga-notifications/-/pipelines/36170

```
# github.com/icinga/icinga-notifications/internal/object [github.com/icinga/icinga-notifications/internal/object.test]
internal/object/objects_test.go:26:18: cannot use 1720702049000 (untyped int constant) as int value in map literal (overflows)
ok  	github.com/icinga/icinga-notifications/cmd/channels/email	0.099s
?   	github.com/icinga/icinga-notifications/cmd/channels/rocketchat	[no test files]
?   	github.com/icinga/icinga-notifications/cmd/channels/webhook	[no test files]
?   	github.com/icinga/icinga-notifications/cmd/icinga-notifications	[no test files]
?   	github.com/icinga/icinga-notifications/internal	[no test files]
?   	github.com/icinga/icinga-notifications/internal/channel	[no test files]
?   	github.com/icinga/icinga-notifications/internal/config	[no test files]
?   	github.com/icinga/icinga-notifications/internal/config/baseconf	[no test files]
?   	github.com/icinga/icinga-notifications/internal/contracts	[no test files]
?   	github.com/icinga/icinga-notifications/internal/daemon	[no test files]
?   	github.com/icinga/icinga-notifications/internal/event	[no test files]
ok  	github.com/icinga/icinga-notifications/internal/filter	0.092s
ok  	github.com/icinga/icinga-notifications/internal/icinga2	0.150s
ok  	github.com/icinga/icinga-notifications/internal/incident	0.123s
?   	github.com/icinga/icinga-notifications/internal/listener	[no test files]
FAIL	github.com/icinga/icinga-notifications/internal/object [build failed]
ok  	github.com/icinga/icinga-notifications/internal/recipient	72.375s
?   	github.com/icinga/icinga-notifications/internal/rule	[no test files]
?   	github.com/icinga/icinga-notifications/internal/testutils	[no test files]
ok  	github.com/icinga/icinga-notifications/internal/timeperiod	0.144s
ok  	github.com/icinga/icinga-notifications/internal/utils	0.123s
?   	github.com/icinga/icinga-notifications/pkg/plugin	[no test files]
ok  	github.com/icinga/icinga-notifications/pkg/rpc	0.176s
FAIL
```

### After

https://git.icinga.com/packages/icinga-notifications/-/pipelines/36171

```
ok  	github.com/icinga/icinga-notifications/cmd/channels/email	(cached)
?   	github.com/icinga/icinga-notifications/cmd/channels/rocketchat	[no test files]
?   	github.com/icinga/icinga-notifications/cmd/channels/webhook	[no test files]
?   	github.com/icinga/icinga-notifications/cmd/icinga-notifications	[no test files]
?   	github.com/icinga/icinga-notifications/internal	[no test files]
?   	github.com/icinga/icinga-notifications/internal/channel	[no test files]
?   	github.com/icinga/icinga-notifications/internal/config	[no test files]
?   	github.com/icinga/icinga-notifications/internal/config/baseconf	[no test files]
?   	github.com/icinga/icinga-notifications/internal/contracts	[no test files]
?   	github.com/icinga/icinga-notifications/internal/daemon	[no test files]
?   	github.com/icinga/icinga-notifications/internal/event	[no test files]
ok  	github.com/icinga/icinga-notifications/internal/filter	(cached)
ok  	github.com/icinga/icinga-notifications/internal/icinga2	(cached)
ok  	github.com/icinga/icinga-notifications/internal/incident	(cached)
?   	github.com/icinga/icinga-notifications/internal/listener	[no test files]
ok  	github.com/icinga/icinga-notifications/internal/object	0.084s
ok  	github.com/icinga/icinga-notifications/internal/recipient	(cached)
?   	github.com/icinga/icinga-notifications/internal/rule	[no test files]
?   	github.com/icinga/icinga-notifications/internal/testutils	[no test files]
ok  	github.com/icinga/icinga-notifications/internal/timeperiod	(cached)
ok  	github.com/icinga/icinga-notifications/internal/utils	(cached)
?   	github.com/icinga/icinga-notifications/pkg/plugin	[no test files]
ok  	github.com/icinga/icinga-notifications/pkg/rpc	(cached)
```