### PR TITLE
Incremental Sync: Fix Rule Recipients Deletion

### DIFF
--- a/internal/config/rule.go
+++ b/internal/config/rule.go
@@ -107,7 +107,7 @@ func (r *RuntimeConfig) applyPendingRules() {
 			}
 
 			escalation.Recipients = slices.DeleteFunc(escalation.Recipients, func(recipient *rule.EscalationRecipient) bool {
-				return recipient.EscalationID == delElement.EscalationID
+				return recipient.ID == delElement.ID
 			})
 			return nil
 		})


### PR DESCRIPTION
The deletion function for escalation rule recipients cleared all recipients in the escalation object based on the escalation ID, not the recipient ID. Thus, if one escalation recipient was either deleted or altered, all recipients were removed from the escalation.

This change fixes the incorrect deletion filter.

In addition, I have looked for similar errors at other incrementalApplyPending calls. Luckily, I have found none.

Fixes #330.