### PR TITLE
Channel: Recreate Logger After Name Change

### DIFF
--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -51,7 +51,7 @@ type newConfig struct {
 
 // Start initializes the channel and starts the plugin in the background
 func (c *Channel) Start(ctx context.Context, logger *zap.SugaredLogger) {
-	c.Logger = logger
+	c.Logger = logger.With(zap.Object("channel", c))
 	c.restartCh = make(chan newConfig)
 	c.pluginCh = make(chan *Plugin)
 	c.pluginCtx, c.pluginCtxCancel = context.WithCancel(ctx)
@@ -153,7 +153,8 @@ func (c *Channel) Stop() {
 }
 
 // Restart signals to restart the channel plugin with the updated channel config
-func (c *Channel) Restart() {
+func (c *Channel) Restart(logger *zap.SugaredLogger) {
+	c.Logger = logger.With(zap.Object("channel", c))
 	c.Logger.Info("Restarting the channel plugin due to a config change")
 	c.restartCh <- newConfig{c.Type, c.Config}
 }

--- a/internal/config/channel.go
+++ b/internal/config/channel.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"github.com/icinga/icinga-notifications/internal/channel"
-	"go.uber.org/zap"
 )
 
 // applyPendingChannels synchronizes changed channels.
@@ -12,9 +11,7 @@ func (r *RuntimeConfig) applyPendingChannels() {
 		r,
 		&r.Channels, &r.configChange.Channels,
 		func(newElement *channel.Channel) error {
-			newElement.Start(context.TODO(), r.logs.GetChildLogger("channel").With(
-				zap.Int64("id", newElement.ID),
-				zap.String("name", newElement.Name)))
+			newElement.Start(context.TODO(), r.logs.GetChildLogger("channel").SugaredLogger)
 			return nil
 		},
 		func(curElement, update *channel.Channel) error {
@@ -22,7 +19,7 @@ func (r *RuntimeConfig) applyPendingChannels() {
 			curElement.Name = update.Name
 			curElement.Type = update.Type
 			curElement.Config = update.Config
-			curElement.Restart()
+			curElement.Restart(r.logs.GetChildLogger("channel").SugaredLogger)
 			return nil
 		},
 		func(delElement *channel.Channel) error {


### PR DESCRIPTION
When restarting a channel, recreate its logger based on the current fields since they may have changed due to reconfiguration.

As a related change, use the Channel.MarshalLogObject method instead of populating the fields in incrementalApplyPending's createFn handler. Unfortunately, zap caches the result from the zap.Object function call and not re-evaluates it every time the logger is used. That is the reason for recreating the logger in the Channel.Restart method.

Fixes #309.