### PR TITLE
incident: reorder `[Un]Mute` & notifications history generation

### DIFF
--- a/internal/incident/sync.go
+++ b/internal/incident/sync.go
@@ -161,7 +161,9 @@ func (i *Incident) generateNotifications(
 
 			if err := hr.Sync(ctx, i.db, tx); err != nil {
 				i.logger.Errorw("Failed to insert incident notification history",
-					zap.String("contact", contact.FullName), zap.Bool("incident_muted", i.Object.IsMuted()),
+					zap.String("contact", contact.FullName),
+					zap.Bool("incident_muted", i.isMuted),
+					zap.Bool("object_muted", i.Object.IsMuted()),
 					zap.Error(err))
 				return nil, err
 			}


### PR DESCRIPTION
So that the incident `muted` history appears logically after the just generated notifications, we must insert the `muted` history last. This way, the history entries will make sense when listed in chronological order in the UI. The `unmute` history entry, on the other hand, must be inserted first, so that the notifications generated below it appear logically after the `unmute` event. This way, when viewing the incident history in the UI, first the `unmute` event will appear and then notifications that were sent after unmuting.

This PR is supposed to allow sending non-state notifications but since this functionality is already implemented, no further changes are necessary here.

refs #106