### PR TITLE
config: NoRulesVersion for initial comparisons

### DIFF
--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -164,11 +164,15 @@ func (r *RuntimeConfig) GetRuleEscalation(escalationID int64) *rule.Escalation {
 	return nil
 }
 
-const MissingRuleVersion = "N/A"
+// NoRulesVersion is a source.RulesInfo version implying that no rules are available for this source.
+//
+// Setting this to the empty string lets comparisons with an empty rule version evaluate to true, which conveniently
+// reduces the amount of rule exchanges between a source and this daemon on a clean setup.
+const NoRulesVersion = ""
 
 // GetRulesVersionFor retrieves the version of the rules for a specific source.
 //
-// If either no rules or no rule for this source exist, MissingRuleVersion is returned.
+// If either no rules or no rule for this source exist, NoRulesVersion is returned.
 //
 // May not be called while holding the write lock on the RuntimeConfig.
 func (r *RuntimeConfig) GetRulesVersionFor(srcId int64) string {
@@ -181,7 +185,7 @@ func (r *RuntimeConfig) GetRulesVersionFor(srcId int64) string {
 		}
 	}
 
-	return MissingRuleVersion
+	return NoRulesVersion
 }
 
 // GetContact returns *recipient.Contact by the given username (case-insensitive).

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -306,7 +306,9 @@ func (l *Listener) DumpRules(w http.ResponseWriter, r *http.Request) {
 //
 // Internally, it converts the data to [baseSource.RulesInfo], being serialized JSON-encoded.
 func (l *Listener) writeSourceRulesInfo(w http.ResponseWriter, source *config.Source) {
-	var rulesInfo baseSource.RulesInfo
+	rulesInfo := baseSource.RulesInfo{
+		Version: config.NoRulesVersion,
+	}
 
 	func() { // Use a function to ensure that the RLock and RUnlock are called before writing the response.
 		l.runtimeConfig.RLock()


### PR DESCRIPTION
Change the rule version string for empty or no rules from the wayward "N/A" string to an empty string.

Doing so lets comparisons with an empty rule version evaluate to true, which conveniently reduces the amount of rule exchanges between a source and this daemon on a clean setup.

In addition, explicitly set the version to [NoRules](https://www.youtube.com/watch?v=7nidDtyS0Wo)Version. This was also done in Listener.writeSourceRulesInfo, even if this now has no real effect. However, before this method returned an empty string version, while the rule comparison expected "N/A", resulting in rejected submissions.