### PR TITLE
Listener: add /incidents endpoint

### DIFF
--- a/doc/20-HTTP-API.md
+++ b/doc/20-HTTP-API.md
@@ -57,6 +57,34 @@ curl -v -u 'source-2:insecureinsecure' -d '@-' 'http://localhost:5680/process-ev
 EOF
 ```
 
+### Get Incidents
+
+A source can query the list of open incidents belonging to its objects using the `/incidents` HTTP API endpoint.
+
+The authentication is performed via HTTP Basic Authentication using the source's username and password.
+
+```
+$ curl -u 'example:insecureinsecure' 'http://localhost:5680/incidents'
+[
+  {
+    "incident_id": "#23",
+    "object_tags": {
+      "host": "mailserver",
+      "service": "filesystem"
+    },
+    "severity": "crit"
+  },
+  {
+    "incident_id": "#42",
+    "object_tags": {
+      "host": "database",
+      "service": "load"
+    },
+    "severity": "err"
+  }
+]
+```
+
 ## Debugging Endpoints
 
 There are multiple endpoints for dumping specific configurations.

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -200,6 +200,20 @@ func GetCurrentIncidents() map[int64]*Incident {
 	return m
 }
 
+// GetCurrentIncidentsForSource returns a slice containing all currently open incidents belonging to a source.
+func GetCurrentIncidentsForSource(sourceID int64) []*Incident {
+	currentIncidentsMu.Lock()
+	defer currentIncidentsMu.Unlock()
+
+	var result []*Incident
+	for _, incident := range currentIncidents {
+		if incident.Object.SourceID == sourceID {
+			result = append(result, incident)
+		}
+	}
+	return result
+}
+
 // ProcessEvent from an event.Event.
 //
 // This function first gets this Event's object.Object and its incident.Incident. Then, after performing some safety


### PR DESCRIPTION
Add an API endpoint for sources to query all incidents belonging to them. This allows sources to detect incidents for obsolete objects, i.e. objects that disappeared or were deleted while they had an ongoing incident.

Added primarily for Icinga for Kubernetes, but could be useful for other sources as well.
