### PR TITLE
doc: remove preview warning

### DIFF
--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -1,11 +1,5 @@
 # Icinga Notifications
 
-!!! warning
-
-    This is an early preview version for you to try, but do not use this in production.
-    There may still be severe bugs and incompatible changes may happen without any notice.
-    At the moment, we don't yet provide any support for this.
-
 Icinga Notifications is a set of components that processes received events from various sources, manages incidents and
 forwards notifications to predefined contacts, consisting of:
 


### PR DESCRIPTION
This change was explicitly requested by @lippserd  as the warning may stop user from trying it. The removal is not supposed to imply that this no longer a preview version.