### PR TITLE
Environment Variable Configuration and Password File Configuration

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -7,6 +7,7 @@
 
 # Set credentials for some debug endpoints provided via HTTP. If not set, these are disabled.
 #debug-password: "put-something-secret-here"
+#debug-password_file: /run/secerets/icinga_notifications_debug_password
 
 # The base Icinga Web 2 URL being used as the base URL for all object, notification and event URLs.
 icingaweb2-url: http://localhost/icingaweb2/
@@ -36,6 +37,7 @@ database:
 
   # Database password.
   password: CHANGEME
+#  password_file: /run/secerets/icinga_notifications_database_password
 
 # Icinga Notifications logs its activities at various severity levels and any errors that occur either
 # on the console or in systemd's journal. The latter is used automatically when running under systemd.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -4,12 +4,25 @@ The configuration for Icinga Notifications is twofold.
 The main configuration resides in the database,
 shared between the Icinga Notifications daemon and Icinga Notifications Web.
 However, as the Icinga Notifications daemon needs to know how to access this database and some further settings,
-it needs its own configuration file as well.
+it needs its own configuration as well.
 
-This configuration is stored in `/etc/icinga-notifications/config.yml`.
+This configuration may be a YAML file, environment variables, or both.
+Environment variables take precedence and override previously defined values from the configuration file.
+
+The YAML configuration file is stored in `/etc/icinga-notifications/config.yml`.
 See [config.example.yml](../config.example.yml) for an example configuration.
 
+The following subsections describe the configurations of the various modules.
+For the YAML configuration file, each option is written in lowercase, as shown in the tables.
+When using environment variables, the variable name is constructed by concatenating `ICINGA_NOTIFICATIONS_`,
+the module name in uppercase followed by an underscore, and the option name in uppercase.
+The hyphens in the names are to be replaced by underscores.
+For example, to set the database host, the `ICINGA_NOTIFICATIONS_DATABASE_HOST` environment variable is used.
+
 ## Top Level Configuration
+
+For YAML configuration, these options are on the top level, not part of a dictionary.
+For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_`.
 
 ### HTTP API Configuration
 
@@ -38,6 +51,9 @@ It may also be `/usr/lib/icinga-notifications/channels`, depending on the operat
 Connection configuration for the database where Icinga Notifications stores configuration and historical data.
 This is also the database used in Icinga Notifications Web to view and work with the data.
 
+For YAML configuration, the options are part of the `database` dictionary.
+For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_DATABASE_`.
+
 | Option   | Description                                                                                                                                               |
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | type     | **Optional.** Either `mysql` (default) or `pgsql`.                                                                                                        |
@@ -64,6 +80,9 @@ manual adjustments.
 
     Do not change the defaults if you do not have to!
 
+For YAML configuration, the options are part of the `database.options` dictionary.
+For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_DATABASE_OPTIONS_`.
+
 | Option                         | Description                                                                                                                                                 |
 |--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | max_connections                | **Optional.** Maximum number of database connections Icinga Notifications is allowed to open in parallel if necessary. Defaults to `16`.                    |
@@ -76,6 +95,9 @@ manual adjustments.
 
 Configuration of the logging component used by Icinga Notifications.
 
+For YAML configuration, the options are part of the `logging` dictionary.
+For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_LOGGING_`.
+
 | Option   | Description                                                                                                                                                                                                                                           |
 |----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | level    | **Optional.** Specifies the default logging level. Can be set to `fatal`, `error`, `warn`, `info` or `debug`. Defaults to `info`.                                                                                                                     |
@@ -84,6 +106,32 @@ Configuration of the logging component used by Icinga Notifications.
 | options  | **Optional.** Map of component name to logging level in order to set a different logging level for each component instead of the default one. See [logging components](#logging-components) for details.                                              |
 
 ### Logging Components
+
+The independent components of Icinga Notifications produce log entries.
+Each log entry is linked to its component and a log level.
+
+By default, any log message will be displayed if its log level is at or above the `level` configured above.
+However, it is possible to override the log level for each component individually to show more or less information.
+
+For YAML configuration, the options are part of the `logging.options` dictionary.
+For environment variables, `ICINGA_NOTIFICATIONS_LOGGING_OPTIONS` expects a single string of `component:level` pairs joined with `,`.
+
+The following example would log everything with at least info level, except database and listener entries, where the level is one time raised and one time lowered.
+
+```yaml
+# YAML Configuration File
+logging:
+  level: info
+  options:
+    database: error
+    listener: debug
+```
+
+```
+# Environment Variables
+ICINGA_NOTIFICATIONS_LOGGING_LEVEL=error
+ICINGA_NOTIFICATIONS_LOGGING_OPTIONS=database:error,listener:debug
+```
 
 | Component       | Description                                                               |
 |-----------------|---------------------------------------------------------------------------|

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -19,6 +19,9 @@ the module name in uppercase followed by an underscore, and the option name in u
 The hyphens in the names are to be replaced by underscores.
 For example, to set the database host, the `ICINGA_NOTIFICATIONS_DATABASE_HOST` environment variable is used.
 
+Passwords can be set directly or stored in a separate file, referenced via the `password_file` YAML key or `PASSWORD_FILE` environment variable.
+Only one of these two options can be used.
+
 ## Top Level Configuration
 
 For YAML configuration, these options are on the top level, not part of a dictionary.
@@ -28,10 +31,11 @@ For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_`.
 
 The HTTP API listener can be used both for submission and for debugging purposes.
 
-| Option         | Description                                                          |
-|----------------|----------------------------------------------------------------------|
-| listen         | Address to bind to, port included. (Example: `localhost:5680`)       |
-| debug-password | Password expected via HTTP Basic Authentication for debug endpoints. |
+| Option              | Description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| listen              | Address to bind to, port included. (Example: `localhost:5680`)       |
+| debug-password      | Password expected via HTTP Basic Authentication for debug endpoints. |
+| debug-password_file | `debug-password` in a file.                                          |
 
 ### Icinga Web 2
 
@@ -54,20 +58,21 @@ This is also the database used in Icinga Notifications Web to view and work with
 For YAML configuration, the options are part of the `database` dictionary.
 For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_DATABASE_`.
 
-| Option   | Description                                                                                                                                               |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| type     | **Optional.** Either `mysql` (default) or `pgsql`.                                                                                                        |
-| host     | **Required.** Database host or absolute Unix socket path.                                                                                                 |
-| port     | **Optional.** Database port. By default, the MySQL or PostgreSQL port, depending on the database type.                                                    |
-| database | **Required.** Database name.                                                                                                                              |
-| user     | **Required.** Database username.                                                                                                                          |
-| password | **Optional.** Database password.                                                                                                                          |
-| tls      | **Optional.** Whether to use TLS.                                                                                                                         |
-| cert     | **Optional.** Path to TLS client certificate.                                                                                                             |
-| key      | **Optional.** Path to TLS private key.                                                                                                                    |
-| ca       | **Optional.** Path to TLS CA certificate.                                                                                                                 |
-| insecure | **Optional.** Whether not to verify the peer.                                                                                                             |
-| options  | **Optional.** List of low-level [database options](#database-options) that can be set to influence some Icinga Notifications internal default behaviours. |
+| Option        | Description                                                                                                                                               |
+|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type          | **Optional.** Either `mysql` (default) or `pgsql`.                                                                                                        |
+| host          | **Required.** Database host or absolute Unix socket path.                                                                                                 |
+| port          | **Optional.** Database port. By default, the MySQL or PostgreSQL port, depending on the database type.                                                    |
+| database      | **Required.** Database name.                                                                                                                              |
+| user          | **Required.** Database username.                                                                                                                          |
+| password      | **Optional.** Database password.                                                                                                                          |
+| password_file | **Optional.** Database password file.                                                                                                                     |
+| tls           | **Optional.** Whether to use TLS.                                                                                                                         |
+| cert          | **Optional.** Path to TLS client certificate.                                                                                                             |
+| key           | **Optional.** Path to TLS private key.                                                                                                                    |
+| ca            | **Optional.** Path to TLS CA certificate.                                                                                                                 |
+| insecure      | **Optional.** Whether not to verify the peer.                                                                                                             |
+| options       | **Optional.** List of low-level [database options](#database-options) that can be set to influence some Icinga Notifications internal default behaviours. |
 
 ### Database Options
 

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -17,12 +17,13 @@ const (
 )
 
 type ConfigFile struct {
-	Listen        string          `yaml:"listen" env:"LISTEN" default:"localhost:5680"`
-	DebugPassword string          `yaml:"debug-password" env:"DEBUG_PASSWORD"`
-	ChannelsDir   string          `yaml:"channels-dir" env:"CHANNELS_DIR"`
-	Icingaweb2URL string          `yaml:"icingaweb2-url" env:"ICINGAWEB2_URL"`
-	Database      database.Config `yaml:"database" envPrefix:"DATABASE_"`
-	Logging       logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
+	Listen            string          `yaml:"listen" env:"LISTEN" default:"localhost:5680"`
+	DebugPassword     string          `yaml:"debug-password" env:"DEBUG_PASSWORD"`
+	DebugPasswordFile string          `yaml:"debug-password_file" env:"DEBUG_PASSWORD_FILE"`
+	ChannelsDir       string          `yaml:"channels-dir" env:"CHANNELS_DIR"`
+	Icingaweb2URL     string          `yaml:"icingaweb2-url" env:"ICINGAWEB2_URL"`
+	Database          database.Config `yaml:"database" envPrefix:"DATABASE_"`
+	Logging           logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
 }
 
 // SetDefaults implements the defaults.Setter interface.
@@ -35,6 +36,9 @@ func (c *ConfigFile) SetDefaults() {
 // Validate implements the config.Validator interface.
 // Validates the entire daemon configuration on daemon startup.
 func (c *ConfigFile) Validate() error {
+	if err := config.LoadPasswordFile(&c.DebugPassword, c.DebugPasswordFile); err != nil {
+		return err
+	}
 	if err := c.Database.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Enable configuration via environment variables via the IGL code as also done in Icinga DB. The configuration sections were copied from Icinga DB and slightly adjusted.

Fixes #370.

---

Password File Configuration

Implement and document the password file support from the latest IGL change[^0], as already did in Icinga DB[^1].

[^0]: https://github.com/Icinga/icinga-go-library/pull/180
[^1]: https://github.com/Icinga/icingadb/pull/1072

---

Closes #148.