### PR TITLE
golangci-lint/sqlclosecheck: Address false positive

### DIFF
--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -36,6 +36,7 @@ func LoadOpenIncidents(ctx context.Context, db *database.DB, logger *logging.Log
 	g.Go(func() error {
 		defer close(incidents)
 
+		//nolint:sqlclosecheck // False positive, does not detect deferred close: https://github.com/ryanrolds/sqlclosecheck/issues/43
 		rows, err := db.QueryxContext(ctx, db.BuildSelectStmt(new(Incident), new(Incident))+` WHERE "recovered_at" IS NULL`)
 		if err != nil {
 			return err

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,6 +18,7 @@ func ExecAndApply[Row any](ctx context.Context, db *database.DB, stmt string, ar
 	}
 	defer sem.Release(1)
 
+	//nolint:sqlclosecheck // False positive, does not detect deferred close: https://github.com/ryanrolds/sqlclosecheck/issues/43
 	rows, err := db.QueryxContext(ctx, db.Rebind(stmt), args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
With a recent golangci-lint update, the bundled sqlclosecheck version was bumped to v0.6.0, resulting in false positives when calling *DB.QueryContext.

https://github.com/ryanrolds/sqlclosecheck/issues/43

For the moment, a nolint annotation was added to please the CI.