### PR TITLE
Add `notifications_schema` table & verify on daemon startup

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -45,6 +45,10 @@ func main() {
 		logger.Fatalf("Cannot connect to the database: %+v", err)
 	}
 
+	if err := internal.CheckSchema(ctx, db); err != nil {
+		logger.Fatalf("%+v", err)
+	}
+
 	channel.UpsertPlugins(ctx, conf.ChannelsDir, logs.GetChildLogger("channel"), db)
 
 	runtimeConfig := config.NewRuntimeConfig(logs, db)

--- a/internal/schema.go
+++ b/internal/schema.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/icinga/icinga-go-library/backoff"
+	"github.com/icinga/icinga-go-library/database"
+	"github.com/icinga/icinga-go-library/retry"
+)
+
+const (
+	// Both MySQL and PostgreSQL schema versions are currently the same, but they can
+	// evolve independently in the future, so can't be merged into a single constant.
+	expectedMysqlSchemaVersion    = "v1.0"
+	expectedPostgresSchemaVersion = "v1.0"
+)
+
+// CheckSchema verifies that the database schema version matches the expected version for the database driver.
+func CheckSchema(ctx context.Context, db *database.DB) error {
+	var expectedSchemaVersion string
+	switch db.DriverName() {
+	case database.MySQL:
+		expectedSchemaVersion = expectedMysqlSchemaVersion
+	case database.PostgreSQL:
+		expectedSchemaVersion = expectedPostgresSchemaVersion
+	default:
+		return fmt.Errorf("unsupported database driver %q", db.DriverName())
+	}
+
+	if hasSchemaTable, err := db.HasTable(ctx, "notifications_schema"); err != nil {
+		return fmt.Errorf("cannot verify existence of database schema table: %w", err)
+	} else if !hasSchemaTable {
+		return errors.New(
+			"notifications_schema table does not exist, please make sure you have applied all" +
+				" database migrations after upgrading Icinga Notifications",
+		)
+	}
+
+	var dbResult []string
+	err := retry.WithBackoff(
+		ctx,
+		func(ctx context.Context) error {
+			qs := `SELECT version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1`
+			if err := db.SelectContext(ctx, &dbResult, qs); err != nil {
+				return database.CantPerformQuery(err, qs)
+			}
+			return nil
+		},
+		retry.Retryable,
+		backoff.DefaultBackoff,
+		db.GetDefaultRetrySettings(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(dbResult) == 0 {
+		return errors.New("no database schema version found")
+	}
+
+	if actualSchemaVersion := dbResult[0]; actualSchemaVersion != expectedSchemaVersion {
+		return fmt.Errorf(
+			"unexpected database schema version: %s (expected %s), please make sure you have applied all"+
+				" database migrations after upgrading Icinga Notifications",
+			actualSchemaVersion, expectedSchemaVersion,
+		)
+	}
+
+	return nil
+}

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1,3 +1,30 @@
+DROP PROCEDURE IF EXISTS assert_correct_schema_version;
+DELIMITER //
+-- This procedure can be used in upgrade scripts to assert that the schema version in the database matches the
+-- expected version before applying the upgrade. This is important to prevent users from accidentally skipping
+-- intermediate upgrade scripts, which could lead to an inconsistent database state. For instance, since every
+-- upgrade script knows its predecessor's version, we can just do "CALL assert_correct_schema_version('v1.0')"
+-- at the beginning of the 1.x upgrade scripts to ensure that the 1.0 script has been applied before.
+CREATE PROCEDURE assert_correct_schema_version(expected_version text)
+    READS SQL DATA
+    COMMENT 'Asserts that the schema version in the database matches the expected version and raises an error if not.'
+BEGIN
+    DECLARE actual_version text;
+    DECLARE error_message text;
+    SELECT version INTO actual_version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1;
+    IF actual_version IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Schema version not found in notifications_schema table.';
+    ELSEIF actual_version != expected_version THEN
+        -- MySQL/MariaDB doesn't seem to allow to directly use CONCAT in the SIGNAL statement[^1],
+        -- so we need to set it to a variable first.
+        -- [^1]: https://bugs.mysql.com/bug.php?id=114001
+        SET error_message = CONCAT('Schema version mismatch: expected ', expected_version, ', got ', actual_version, '. Please apply all previous upgrade scripts in order before applying this one.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_message;
+    END IF;
+END;
+//
+DELIMITER ;
+
 CREATE TABLE available_channel_type (
     type varchar(255) NOT NULL,
     name text NOT NULL,
@@ -444,3 +471,14 @@ CREATE TABLE browser_session (
 
 CREATE INDEX idx_browser_session_authenticated_at ON browser_session (authenticated_at DESC);
 CREATE INDEX idx_browser_session_username_agent ON browser_session (username, user_agent(512));
+
+CREATE TABLE notifications_schema (
+    id int NOT NULL AUTO_INCREMENT,
+    version varchar(64) NOT NULL,
+    timestamp bigint NOT NULL,
+
+    CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+    CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO notifications_schema(version, timestamp) VALUES('v1.0', UNIX_TIMESTAMP() * 1000);

--- a/schema/mysql/upgrades/003.sql
+++ b/schema/mysql/upgrades/003.sql
@@ -1,0 +1,34 @@
+DROP PROCEDURE IF EXISTS assert_correct_schema_version;
+DELIMITER //
+-- This procedure can be used in upgrade scripts to assert that the schema version in the database matches the
+-- expected version before applying the upgrade. This is important to prevent users from accidentally skipping
+-- intermediate upgrade scripts, which could lead to an inconsistent database state. For instance, since every
+-- upgrade script knows its predecessor's version, we can just do "CALL assert_correct_schema_version('v1.0')"
+-- at the beginning of the 1.x upgrade scripts to ensure that the 1.0 script has been applied before.
+CREATE PROCEDURE assert_correct_schema_version(expected_version text)
+    READS SQL DATA
+    COMMENT 'Asserts that the schema version in the database matches the expected version and raises an error if not.'
+BEGIN
+    DECLARE actual_version text;
+    DECLARE error_message text;
+    SELECT version INTO actual_version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1;
+    IF actual_version IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Schema version not found in notifications_schema table.';
+    ELSEIF actual_version != expected_version THEN
+        SET error_message = CONCAT('Schema version mismatch: expected ', expected_version, ', got ', actual_version, '. Please apply all previous upgrade scripts in order before applying this one.');
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_message;
+    END IF;
+END;
+//
+DELIMITER ;
+
+CREATE TABLE notifications_schema (
+    id int NOT NULL AUTO_INCREMENT,
+    version varchar(64) NOT NULL,
+    timestamp bigint NOT NULL,
+
+    CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+    CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO notifications_schema(version, timestamp) VALUES('v1.0', UNIX_TIMESTAMP() * 1000);

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -30,6 +30,26 @@ CREATE OR REPLACE FUNCTION anynonarrayliketext(anynonarray, text)
     $$;
 CREATE OPERATOR ~~ (LEFTARG=anynonarray, RIGHTARG=text, PROCEDURE=anynonarrayliketext);
 
+-- This procedure can be used in upgrade scripts to assert that the schema version in the database matches the
+-- expected version before applying the upgrade. This is important to prevent users from accidentally skipping
+-- intermediate upgrade scripts, which could lead to an inconsistent database state. For instance, since every
+-- upgrade script knows its predecessor's version, we can just do "CALL assert_correct_schema_version('v1.0')"
+-- at the beginning of the 1.x upgrade scripts to ensure that the 1.0 script has been applied before.
+CREATE OR REPLACE PROCEDURE assert_correct_schema_version(expected_version text)
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    actual_version text := (SELECT version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1);
+BEGIN
+    IF actual_version IS NULL THEN
+        RAISE 'Schema version not found in notifications_schema table.';
+    ELSIF actual_version != expected_version THEN
+        RAISE 'Schema version mismatch: expected %, got %. Please apply all previous upgrade scripts in order before applying this one.', expected_version, actual_version;
+    END IF;
+END;
+$$;
+COMMENT ON PROCEDURE assert_correct_schema_version IS 'Asserts that the schema version in the database matches the expected version and raises an error if not.';
+
 CREATE TABLE available_channel_type (
     type varchar(255) NOT NULL,
     name text NOT NULL,
@@ -490,3 +510,14 @@ CREATE TABLE browser_session (
 
 CREATE INDEX idx_browser_session_authenticated_at ON browser_session (authenticated_at DESC);
 CREATE INDEX idx_browser_session_username_agent ON browser_session (username, user_agent);
+
+CREATE TABLE notifications_schema (
+    id serial,
+    version varchar(64) NOT NULL,
+    timestamp bigint NOT NULL,
+
+    CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+    CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+);
+
+INSERT INTO notifications_schema(version, timestamp) VALUES('v1.0', EXTRACT(EPOCH from NOW()) * 1000);

--- a/schema/pgsql/upgrades/003.sql
+++ b/schema/pgsql/upgrades/003.sql
@@ -1,0 +1,30 @@
+-- This procedure can be used in upgrade scripts to assert that the schema version in the database matches the
+-- expected version before applying the upgrade. This is important to prevent users from accidentally skipping
+-- intermediate upgrade scripts, which could lead to an inconsistent database state. For instance, since every
+-- upgrade script knows its predecessor's version, we can just do "CALL assert_correct_schema_version('v1.0')"
+-- at the beginning of the 1.x upgrade scripts to ensure that the 1.0 script has been applied before.
+CREATE OR REPLACE PROCEDURE assert_correct_schema_version(expected_version text)
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    actual_version text := (SELECT version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1);
+BEGIN
+    IF actual_version IS NULL THEN
+        RAISE 'Schema version not found in notifications_schema table.';
+    ELSIF actual_version != expected_version THEN
+        RAISE 'Schema version mismatch: expected %, got %. Please apply all previous upgrade scripts in order before applying this one.', expected_version, actual_version;
+    END IF;
+END;
+$$;
+COMMENT ON PROCEDURE assert_correct_schema_version IS 'Asserts that the schema version in the database matches the expected version and raises an error if not.';
+
+CREATE TABLE notifications_schema (
+  id serial,
+  version varchar(64) NOT NULL,
+  timestamp bigint NOT NULL,
+
+  CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+  CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+);
+
+INSERT INTO notifications_schema(version, timestamp) VALUES('v1.0', EXTRACT(EPOCH from NOW()) * 1000);


### PR DESCRIPTION
This PR adds a new `notifications_schema` table to the database, which is used to store the schema version for notifications. It quite similar to the one used in Icinga DB, but with a small but important difference: the `version` column is of type `TEXT` instead of `INTEGER` as opposed to Icinga DB. Instead of using an independent integer versioning system that can't be easily determined to which Icinga Notifications version it corresponds, we will use the actual semver version exactly as its upgrade script is named.

In order to prevent users from applying the upgrade scripts out of order or the same script multiple times, any upgrade script after Icinga Notifications `v1.0` will have use an SQL procedure introduced in this PR, which will check if the current version in the `notifications_schema` table matches the expected one before applying the upgrade. If the version does not match, the procedure will raise an error and prevent the upgrade from being applied. For instance, if we have an upgrade script for version `v1.1`, at the top of the script we will have a call to the procedure like this:

```sql
CALL assert_correct_schema_version('v1.0');
```

This ensures that the current upgrade script can only be applied if the current version in the `notifications_schema` table is `v1.0`, which means that the previous upgrade script has been applied. If the current version is not `v1.0`, the procedure will raise an error and prevent the upgrade from being applied, thus ensuring that the upgrade scripts are applied in the correct order and that no script is applied multiple times. And of course, Icinga Notifications performs a check at startup to ensure that the expected schema version is applied before doing anything else, but it doesn't go through the `notifications_schema` entries to determine for missing upgrade scripts since that is supposed to be handled by the upgrade scripts themselves.

resolves #343