### PR TITLE
incidents: don't load incident recipients twice

### DIFF
--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -759,27 +759,6 @@ func (i *Incident) getRecipientsChannel(t time.Time) rule.ContactChannels {
 	return contactChs
 }
 
-// restoreRecipients reloads the current incident recipients from the database.
-// Returns error on database failure.
-func (i *Incident) restoreRecipients(ctx context.Context) error {
-	contact := &ContactRow{}
-	var contacts []*ContactRow
-	err := i.db.SelectContext(ctx, &contacts, i.db.Rebind(i.db.BuildSelectStmt(contact, contact)+` WHERE "incident_id" = ?`), i.Id)
-	if err != nil {
-		i.logger.Errorw("Failed to restore incident recipients from the database", zap.Error(err))
-		return err
-	}
-
-	recipients := make(map[recipient.Key]*RecipientState)
-	for _, contact := range contacts {
-		recipients[contact.Key] = &RecipientState{Role: contact.Role}
-	}
-
-	i.Recipients = recipients
-
-	return nil
-}
-
 // isRecipientNotifiable checks whether the given recipient should be notified about the current incident.
 // If the specified recipient has not yet been notified of this incident, it always returns false.
 // Otherwise, the recipient role is forwarded to IsNotifiable and may or may not return true.

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -149,8 +149,7 @@ func LoadOpenIncidents(ctx context.Context, db *database.DB, logger *logging.Log
 }
 
 func GetCurrent(
-	ctx context.Context, db *database.DB, obj *object.Object, logger *logging.Logger, runtimeConfig *config.RuntimeConfig,
-	create bool,
+	db *database.DB, obj *object.Object, logger *logging.Logger, runtimeConfig *config.RuntimeConfig, create bool,
 ) (*Incident, error) {
 	currentIncidentsMu.Lock()
 	defer currentIncidentsMu.Unlock()
@@ -162,17 +161,6 @@ func GetCurrent(
 		currentIncident = NewIncident(db, obj, runtimeConfig, incidentLogger)
 
 		currentIncidents[obj] = currentIncident
-	}
-
-	if currentIncident != nil {
-		currentIncident.Lock()
-		defer currentIncident.Unlock()
-
-		if !currentIncident.StartedAt.Time().IsZero() {
-			if err := currentIncident.restoreRecipients(ctx); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return currentIncident, nil
@@ -240,7 +228,6 @@ func ProcessEvent(
 
 	createIncident := ev.Severity != baseEv.SeverityNone && ev.Severity != baseEv.SeverityOK
 	currentIncident, err := GetCurrent(
-		ctx,
 		db,
 		obj,
 		logs.GetChildLogger("incident"),


### PR DESCRIPTION
The `LoadOpenIncidents` function already does that for all existing active incidents, so we don't need to re-load them with each ongoing event. This should have been removed with https://github.com/Icinga/icinga-notifications/pull/129 but was overlooked, so we can safely remove it now. Here's the existing code that does the loading of incident recipients for all active incidents:
https://github.com/Icinga/icinga-notifications/blob/710c8184d8ed036fef3bede2838d4c4be5015a53/internal/incident/incidents.go#L115-L118