### PR TITLE
incident: drop special handling of ACK events

### DIFF
--- a/doc/10-Channels.md
+++ b/doc/10-Channels.md
@@ -276,7 +276,6 @@ or if the channel is missing required configuration values.
     "event": {
       "time": "2024-07-12T10:47:30.445439055Z",
       "type": "state",
-      "username": "",
       "message": "Q:\tWhat looks like a cat, flies like a bat, brays like a donkey, and\n\tplays like a monkey?\nA:\tNothing."
     }
   },

--- a/doc/20-HTTP-API.md
+++ b/doc/20-HTTP-API.md
@@ -49,7 +49,6 @@ curl -v -u 'source-2:insecureinsecure' -d '@-' 'http://localhost:5680/process-ev
   },
   "type": "state",
   "severity": "crit",
-  "username": "",
   "message": "Something went somewhere very wrong.",
   "rules_version": "23",
   "rule_ids": ["0"]

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -13,7 +13,6 @@ import (
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
-	"strings"
 	"sync"
 	"time"
 )
@@ -186,18 +185,6 @@ func (r *RuntimeConfig) GetRulesVersionFor(srcId int64) string {
 	}
 
 	return NoRulesVersion
-}
-
-// GetContact returns *recipient.Contact by the given username (case-insensitive).
-// Returns nil when the given username doesn't exist.
-func (r *RuntimeConfig) GetContact(username string) *recipient.Contact {
-	for _, contact := range r.Contacts {
-		if strings.EqualFold(contact.Username.String, username) {
-			return contact
-		}
-	}
-
-	return nil
 }
 
 // GetSourceFromCredentials verifies a credential pair against known Sources.

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -2,7 +2,6 @@ package incident
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/icinga/icinga-go-library/database"
 	baseEv "github.com/icinga/icinga-go-library/notifications/event"
@@ -164,8 +163,7 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event) error {
 		return err
 	}
 
-	switch ev.Type {
-	case baseEv.TypeState:
+	if ev.Type == baseEv.TypeState {
 		if !isNew {
 			if err := i.processSeverityChangedEvent(ctx, tx, ev); err != nil {
 				return err
@@ -183,16 +181,6 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event) error {
 		}
 
 		if err := i.triggerEscalations(ctx, tx, ev, escalations); err != nil {
-			return err
-		}
-	case baseEv.TypeAcknowledgementSet:
-		if err := i.processAcknowledgementEvent(ctx, tx, ev); err != nil {
-			if errors.Is(err, errSuperfluousAckEvent) {
-				// That ack error type indicates that the acknowledgement author was already a manager, thus
-				// we can safely ignore that event and return without even committing the DB transaction.
-				return nil
-			}
-
 			return err
 		}
 	}
@@ -652,67 +640,6 @@ func (i *Incident) notifyContact(contact *recipient.Contact, ev *event.Event, ch
 	return nil
 }
 
-// errSuperfluousAckEvent is returned when the same ack author submits two successive ack set events on an incident.
-// This is error is going to be used only within this incident package.
-var errSuperfluousAckEvent = errors.New("superfluous acknowledgement set event, author is already a manager")
-
-// processAcknowledgementEvent processes the given ack event.
-// Promotes the ack author to incident.RoleManager if it's not already the case and generates a history entry.
-// Returns error on database failure.
-func (i *Incident) processAcknowledgementEvent(ctx context.Context, tx *sqlx.Tx, ev *event.Event) error {
-	contact := i.runtimeConfig.GetContact(ev.Username)
-	if contact == nil {
-		i.logger.Warnw("Ignoring acknowledgement event from an unknown author", zap.String("author", ev.Username))
-
-		return fmt.Errorf("unknown acknowledgment author %q", ev.Username)
-	}
-
-	recipientKey := recipient.ToKey(contact)
-	state := i.Recipients[recipientKey]
-	oldRole := RoleNone
-	newRole := RoleManager
-	if state != nil {
-		oldRole = state.Role
-
-		if oldRole == RoleManager {
-			// The user is already a manager
-			i.logger.Debugw("Ignoring acknowledgement-set event, author is already a manager", zap.String("author", ev.Username))
-			return errSuperfluousAckEvent
-		}
-	} else {
-		i.Recipients[recipientKey] = &RecipientState{Role: newRole}
-	}
-
-	i.logger.Infof("Contact %q role changed from %s to %s", contact.String(), oldRole.String(), newRole.String())
-
-	hr := &HistoryRow{
-		IncidentID:       i.Id,
-		Key:              recipientKey,
-		EventID:          types.MakeInt(ev.ID, types.TransformZeroIntToNull),
-		Type:             RecipientRoleChanged,
-		Time:             types.UnixMilli(time.Now()),
-		NewRecipientRole: newRole,
-		OldRecipientRole: oldRole,
-		Message:          types.MakeString(ev.Message, types.TransformEmptyStringToNull),
-	}
-
-	if err := hr.Sync(ctx, i.db, tx); err != nil {
-		i.logger.Errorw("Failed to add recipient role changed history", zap.String("recipient", contact.String()), zap.Error(err))
-		return err
-	}
-
-	cr := &ContactRow{IncidentID: hr.IncidentID, Key: recipientKey, Role: newRole}
-
-	stmt, _ := i.db.BuildUpsertStmt(cr)
-	_, err := tx.NamedExecContext(ctx, stmt, cr)
-	if err != nil {
-		i.logger.Errorw("Failed to upsert incident contact", zap.String("contact", contact.String()), zap.Error(err))
-		return err
-	}
-
-	return nil
-}
-
 // getRecipientsChannel returns all the configured channels of the current incident and escalation recipients.
 func (i *Incident) getRecipientsChannel(t time.Time) rule.ContactChannels {
 	contactChs := make(rule.ContactChannels)
@@ -728,8 +655,7 @@ func (i *Incident) getRecipientsChannel(t time.Time) rule.ContactChannels {
 	}
 
 	// Check whether all the incident recipients do have an appropriate contact channel configured.
-	// When a recipient has subscribed/managed this incident via the UI or using an ACK, fallback
-	// to the default contact channel.
+	// When a recipient has subscribed/managed this incident via the UI, fallback to the default contact channel.
 	for recipientKey, state := range i.Recipients {
 		r := i.runtimeConfig.GetRecipient(recipientKey)
 		if r == nil {


### PR DESCRIPTION
The ACK event will still be processed just like before, but the special handling of the ACK event promoting the event author to incident manager is now completely removed as requested in the referenced issue. The event type `TypeAcknowledgementSet` and `TypeAcknowledgementCleared` are still not removed from Icinga Go Library, but since we're going to drop the `type` field from the event request with https://github.com/Icinga/icinga-notifications/issues/407 anyway, it's not a problem to keep them around for now and not break existing implementations of Icinga DB with this change. This also applies to the `username` field. It's no longer required but as the event table is going to be dropped anyway with #423, I didn't include any changes regarding this apart from the docs update.

resolves #410