### PR TITLE
Prevent concurrent object access

### DIFF
--- a/.github/workflows/tests_with_database.yml
+++ b/.github/workflows/tests_with_database.yml
@@ -71,12 +71,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 10
-        # By default, multiple packages may be tested in parallel in different
-        # processes. Passing -p 1 reduces this to one process to prevent test
-        # cases in different packages from accessing the same database. Note
-        # that t.Parallel() only affects parallelism within one process, i.e.
-        # within the tests of one package.
-        run: go test -v -timeout 5m -p 1 ./...
+        run: go test -v -timeout 5m ./...
 
   postgresql:
     name: PostgreSQL ${{ matrix.version }}
@@ -130,9 +125,4 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 10
-        # By default, multiple packages may be tested in parallel in different
-        # processes. Passing -p 1 reduces this to one process to prevent test
-        # cases in different packages from accessing the same database. Note
-        # that t.Parallel() only affects parallelism within one process, i.e.
-        # within the tests of one package.
-        run: go test -v -timeout 5m -p 1 ./...
+        run: go test -v -timeout 5m ./...

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -153,6 +153,13 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event) error {
 		}
 
 		i.logger = i.logger.With(zap.String("incident", i.String()))
+	} else {
+		// For all existing incidents, we have to reload the recipients from the database to ensure that we have the
+		// most up-to-date recipient list, since the recipients or recipients roles might have changed since users
+		// are allowed to subscribe or manage incidents from within Icinga Notifications Web.
+		if err := i.restoreRecipients(ctx); err != nil {
+			return err
+		}
 	}
 
 	if ev.Type == baseEv.TypeState {

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -145,6 +145,11 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := i.Object.SyncFromEvent(ctx, tx, ev); err != nil {
+		i.logger.Errorw("Cannot sync event object", zap.Error(err))
+		return fmt.Errorf("cannot sync event object: %w", err)
+	}
+
 	isNew := i.StartedAt.Time().IsZero()
 	if isNew {
 		err = i.processIncidentOpenedEvent(ctx, tx, ev)

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -208,14 +208,9 @@ func ProcessEvent(
 	runtimeConfig *config.RuntimeConfig,
 	ev *event.Event,
 ) error {
-	obj, err := object.FromEvent(ctx, db, ev)
-	if err != nil {
-		return fmt.Errorf("cannot sync event object: %w", err)
-	}
-
 	currentIncident := GetCurrent(
 		db,
-		obj,
+		object.Get(db, ev),
 		logs.GetChildLogger("incident"),
 		runtimeConfig,
 		CanOpenNewIncident(ev))

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -166,11 +166,7 @@ func RemoveCurrent(obj *object.Object) {
 	currentIncidentsMu.Lock()
 	defer currentIncidentsMu.Unlock()
 
-	currentIncident := currentIncidents[obj]
-
-	if currentIncident != nil {
-		delete(currentIncidents, obj)
-	}
+	delete(currentIncidents, obj)
 }
 
 // GetCurrentIncidents returns a map of all incidents for debugging purposes.

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -146,10 +146,7 @@ func LoadOpenIncidents(ctx context.Context, db *database.DB, logger *logging.Log
 	return g.Wait()
 }
 
-func GetCurrent(
-	ctx context.Context, db *database.DB, obj *object.Object, logger *logging.Logger, runtimeConfig *config.RuntimeConfig,
-	create bool,
-) (*Incident, error) {
+func GetCurrent(db *database.DB, obj *object.Object, logger *logging.Logger, runtimeConfig *config.RuntimeConfig, create bool) *Incident {
 	currentIncidentsMu.Lock()
 	defer currentIncidentsMu.Unlock()
 
@@ -162,18 +159,7 @@ func GetCurrent(
 		currentIncidents[obj] = currentIncident
 	}
 
-	if currentIncident != nil {
-		currentIncident.Lock()
-		defer currentIncident.Unlock()
-
-		if !currentIncident.StartedAt.Time().IsZero() {
-			if err := currentIncident.restoreRecipients(ctx); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return currentIncident, nil
+	return currentIncident
 }
 
 func RemoveCurrent(obj *object.Object) {
@@ -231,16 +217,12 @@ func ProcessEvent(
 		return fmt.Errorf("cannot sync event object: %w", err)
 	}
 
-	currentIncident, err := GetCurrent(
-		ctx,
+	currentIncident := GetCurrent(
 		db,
 		obj,
 		logs.GetChildLogger("incident"),
 		runtimeConfig,
 		CanOpenNewIncident(ev))
-	if err != nil {
-		return fmt.Errorf("cannot get current incident for %q: %w", obj.DisplayName(), err)
-	}
 
 	if currentIncident == nil {
 		if ev.Severity == baseEv.SeverityOK {

--- a/internal/incident/incidents_test.go
+++ b/internal/incident/incidents_test.go
@@ -159,10 +159,7 @@ func makeIncident(ctx context.Context, db *database.DB, t *testing.T, sourceID i
 		},
 	}
 
-	o, err := object.FromEvent(ctx, db, ev)
-	require.NoError(t, err)
-
-	i := NewIncident(db, o, &config.RuntimeConfig{}, nil)
+	i := NewIncident(db, object.Get(db, ev), &config.RuntimeConfig{}, nil)
 	i.StartedAt = types.UnixMilli(time.Now().Add(-2 * time.Hour).Truncate(time.Second))
 	i.Severity = baseEv.SeverityCrit
 	if recovered {
@@ -170,10 +167,12 @@ func makeIncident(ctx context.Context, db *database.DB, t *testing.T, sourceID i
 		i.RecoveredAt = types.UnixMilli(time.Now())
 	}
 
-	tx, err := db.BeginTxx(ctx, nil)
-	require.NoError(t, err, "starting a transaction should not fail")
-	require.NoError(t, i.Sync(ctx, tx), "failed to insert incident")
-	require.NoError(t, tx.Commit(), "committing a transaction should not fail")
+	require.NoError(t, db.ExecTx(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		if err := i.Object.SyncFromEvent(ctx, tx, ev); err != nil {
+			return err
+		}
+		return i.Sync(ctx, tx)
+	}))
 
 	return i
 }

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -8,10 +8,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/event"
-	"sort"
+	"github.com/jmoiron/sqlx"
 )
 
 type Object struct {
@@ -54,57 +56,30 @@ func ClearCache() {
 	cache = make(map[string]*Object)
 }
 
-// FromEvent creates an object from the provided event tags if it's not in the cache
-// and syncs all object related types with the database.
-// Returns error on any database failure
-func FromEvent(ctx context.Context, db *database.DB, ev *event.Event) (*Object, error) {
-	id := ID(ev.SourceId, ev.Tags)
+// SyncFromEvent syncs the current object with the given event.
+//
+// It updates all relevant fields and tags of the object and saves it to the database within the given transaction.
+// The current object is updated with the new values only if the database update is successful, otherwise it remains
+// unchanged.
+//
+// Returns error on any database failure.
+func (o *Object) SyncFromEvent(ctx context.Context, tx *sqlx.Tx, ev *event.Event) error {
+	newObject := *o
+	newObject.Name = ev.Name
+	newObject.URL = types.MakeString(ev.URL, types.TransformEmptyStringToNull)
 
-	cacheMu.Lock()
-	defer cacheMu.Unlock()
-
-	newObject := new(Object)
-	object, objectExists := cache[id.String()]
-	if !objectExists {
-		newObject = New(db, ev)
-		newObject.ID = id
-	} else {
-		*newObject = *object
-
-		newObject.Name = ev.Name
-		newObject.URL = types.MakeString(ev.URL, types.TransformEmptyStringToNull)
+	stmt, _ := o.db.BuildUpsertStmt(o)
+	if _, err := tx.NamedExecContext(ctx, stmt, &newObject); err != nil {
+		return fmt.Errorf("failed to insert object: %w", err)
 	}
 
-	tx, err := db.BeginTxx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start object database transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	stmt, _ := db.BuildUpsertStmt(&Object{})
-	_, err = tx.NamedExecContext(ctx, stmt, newObject)
-	if err != nil {
-		return nil, fmt.Errorf("failed to insert object: %w", err)
+	stmt, _ = o.db.BuildUpsertStmt(new(IdTagRow))
+	if _, err := tx.NamedExecContext(ctx, stmt, mapToIdTagRows(newObject.ID, ev.Tags)); err != nil {
+		return fmt.Errorf("failed to upsert object id tags: %w", err)
 	}
 
-	stmt, _ = db.BuildUpsertStmt(&IdTagRow{})
-	_, err = tx.NamedExecContext(ctx, stmt, mapToIdTagRows(newObject.ID, ev.Tags))
-	if err != nil {
-		return nil, fmt.Errorf("failed to upsert object id tags: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return nil, fmt.Errorf("cannot commit object database transaction: %w", err)
-	}
-
-	if !objectExists {
-		cache[id.String()] = newObject
-		return newObject, nil
-	}
-
-	*object = *newObject
-
-	return object, nil
+	*o = newObject
+	return nil
 }
 
 func (o *Object) DisplayName() string {

--- a/internal/object/objects.go
+++ b/internal/object/objects.go
@@ -3,14 +3,16 @@ package object
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/types"
+	"github.com/icinga/icinga-notifications/internal/event"
 	"github.com/icinga/icinga-notifications/internal/utils"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-	"sync"
 )
 
 var (
@@ -24,6 +26,24 @@ func DeleteFromCache(id types.Binary) {
 	defer cacheMu.Unlock()
 
 	delete(cache, id.String())
+}
+
+// Get either fetches an object from cache or creates a new one, adds it to the cache and returns it.
+func Get(db *database.DB, ev *event.Event) *Object {
+	id := ID(ev.SourceId, ev.Tags)
+
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	if object, ok := cache[id.String()]; ok {
+		return object
+	}
+
+	object := New(db, ev)
+	object.ID = id
+	cache[id.String()] = object
+
+	return object
 }
 
 // RestoreObjects restores all objects and their (extra)tags matching the given IDs from the database.


### PR DESCRIPTION
This PR restructures the `Object` and `Incident` lookups and creations a bit to prevent some of the issues we were having as described in the referenced issues. Previously, the event processing logic goes like this:

1. With each ongoing request, we first sync the `Object` into the database in its own transaction. While this is happening, the entire objects cache is locked, so any other request targeting a completely different object will be blocked until the transaction is committed.
2. After the object is successfully synced, we then proceed with the rest of the processing, which includes syncing the  `Incident` and all the related records in a single and long transaction. And of course, while this is happening, the  incident object is locked, so any other request targeting the same incident will be blocked until the ongoing one completes.

This PR changes the logic to the following:

1. With each ongoing request, we first just retrieve the corresponding object from cache, and if it doesn't exist yet,  we simply create a new one in memory without saving it to the database. This way, the objects cache is never locked across database transactions, and any request targeting a completely different object can proceed promptly without being blocked.
2. After the object is retrieved or created in memory, we then use that object to lookup or create the corresponding incident in the incidents cache. Only when enter the `incident.ProcessEvent` function, and acquire the lock for that incident, we will then start a DB tx to sync the incident and all the related records just like before, but this time, the object syncing is included in this very same tx. When we receive another request targeting the same object, it will be blocked in `incident.ProcessEvent` until the ongoing one completes, but other requests can freely proceed without such blocking.

There is one difference between the old and new logic that is worth mentioning. Previously, if we fail to successfully sync the object into the database, it wasn't added to the cache at all, as the cache is only updated after the tx is committed. That's not the case anymore, but since incidents are created/cached in the same way (even with the main branch), I don't have any better way to handle this without introducing more complexity. If in doubt, we can always add some cleanup logic or the like to remove dead objects and incidents from the cache in a later/separate PR if we find it necessary.

resolves #250
resolves #266

## Blocked By
- https://github.com/Icinga/icinga-notifications/pull/423
- https://github.com/Icinga/icinga-notifications/pull/418 (this PR drops all extra tags related code, and would create a nasty merge conflicts. Plus when this PR is merged the failing GHAs will hopefully secceed 🤞🏼)