### PR TITLE
Support HTTPS

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,20 +1,24 @@
-# The address of the Icinga Notifications HTTP listener to be bound to.
-# This can be configured in many different ways, as listed below.
-#listen: "localhost:5680" # default
-#listen: ":5680" # any interface
-#listen: "192.0.2.1:5680"
-#listen: "[2001:db8::1]:5680"
-
-# Set credentials for some debug endpoints provided via HTTP. If not set, these are disabled.
-#debug-password: "put-something-secret-here"
-#debug-password_file: /run/secerets/icinga_notifications_debug_password
-
 # The base Icinga Web 2 URL being used as the base URL for all object, notification and event URLs.
-icingaweb2-url: http://localhost/icingaweb2/
+icingaweb2_url: http://localhost/icingaweb2/
 
 # Directory containing all executable Icinga Notifications channel plugins.
 # By default, all of Icinga Notifications built-in channel plugins are installed in the directory below.
-#channels-dir: /usr/libexec/icinga-notifications/channels
+#channels_dir: /usr/libexec/icinga-notifications/channels
+
+# Icinga Notifications HTTP listener configuration.
+listener:
+  # The TCP address of the Icinga Notifications HTTP listener to listen on, in the form of "host:port".
+  # The host part can be a hostname, an IP address or empty to listen on all interfaces. The port part
+  # must be a valid TCP port number. This can be configured in many different ways, as listed below.
+  # address: "localhost:5680", ":5680" (any interface) or "[2001:db8::1]:5680" (IPv6 only).
+  # Defaults to "localhost:5680".
+  #address: "localhost:5680"
+
+  # Set credentials for all the HTTP debug endpoints. This can be set either directly or read from a file.
+  # Setting both options is not allowed and will result in a configuration error. If both options are left
+  # unset, the debug endpoints will be disabled and won't be accessible at all.
+  #debug_password: "put-something-secret-here"
+  #debug_password_file: /run/secrets/icinga_notifications_debug_password
 
 # Connection configuration for the database where Icinga Notifications stores configuration and historical data.
 # This is also the database used in Icinga Notifications Web to view and work with the data.

--- a/config.example.yml
+++ b/config.example.yml
@@ -20,6 +20,34 @@ listener:
   #debug_password: "put-something-secret-here"
   #debug_password_file: /run/secrets/icinga_notifications_debug_password
 
+  # Set tls to true to enable only secure connections to the Icinga Notifications HTTP listener.
+  # If enabled, the certificate and private key must be set as well. If not set, defaults to false.
+  #tls: false
+
+  # Set the path to the server's public TLS certificate or PEM-encoded multiline string.
+  # If TLS is enabled, this is required and must be set to a valid certificate.
+  #cert: /path/to/server.crt
+
+  # Set the path to the server's private TLS key or PEM-encoded multiline string.
+  # If TLS is enabled, this is required and must be set to a valid private key corresponding to the certificate.
+  #key: /path/to/server.key
+
+  # Set the path to a CA certificate or PEM-encoded multiline string to enable client certificate authentication.
+  #
+  # If the `client_auth` option is set to 'VerifyClientCertIfGiven' or 'RequireAndVerifyClientCert', this option
+  # must be set to a valid CA certificate to verify client certificates against. Otherwise, it's optional and can
+  # be left unset.
+  #ca: /path/to/ca.crt
+
+  # Set the client authentication mode for the Icinga Notifications HTTP listener.
+  #
+  # This can be set to 'NoClientCert' to disable client certificate authentication, 'RequestClientCert' to
+  # request but not require client certificates, 'RequireAnyClientCert' to require any client cert without
+  # verification, 'VerifyClientCertIfGiven' to verify client certificates if provided but not require them,
+  # or 'RequireAndVerifyClientCert' to always require and verify client certificates. If not set, defaults
+  # to 'NoClientCert'.
+  #client_auth: NoClientCert
+
 # Connection configuration for the database where Icinga Notifications stores configuration and historical data.
 # This is also the database used in Icinga Notifications Web to view and work with the data.
 database:

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -47,11 +47,27 @@ Configuration of the HTTP API listener for event submission and debugging endpoi
 For YAML configuration, the options are part of the `listener` section.
 For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_LISTENER_`.
 
-| Option              | Description                                                          |
-|---------------------|----------------------------------------------------------------------|
-| address             | Address to bind to, port included. (Example: `localhost:5680`)       |
-| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints. |
-| debug_password_file | `debug_password` in a file.                                          |
+| Option              | Description                                                                       |
+|---------------------|-----------------------------------------------------------------------------------|
+| address             | Address to bind to, port included. (Example: `localhost:5680`)                    |
+| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints.              |
+| debug_password_file | `debug_password` in a file.                                                       |
+| tls                 | **Optional.** Whether to require TLS for the listener. Defaults to `false`.       |
+| cert                | **Optional.** Path to TLS server certificate. Required if `tls` is set to `true`. |
+| key                 | **Optional.** Path to the TLS private key. Required if `tls` is `true`.           |
+| ca                  | **Optional.** Path to TLS CA cert to verify client certificates.                  |
+| client_auth         | **Optional.** TLS client authentication mode. Defaults to `NoClientCert`.         |
+
+!!! info
+
+    When the `client_auth` option is set to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`, the `ca`
+    option must be set to a valid TLS CA cert to verify client certificates against. Otherwise, it's optional and
+    can be left out.
+
+    The TLS `client_auth` option can either be set to `NoClientCert` to disable client authentication,
+    `RequestClientCert` to request but not require and verify client certificates if provided, `RequireAnyClientCert`
+    to require any client certificate without verification, `VerifyClientCertIfGiven` to verify client certificates if
+    provided, or `RequireAndVerifyClientCert` to always require and verify client certificates.
 
 ## Database Configuration
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -27,28 +27,31 @@ Only one of these two options can be used.
 For YAML configuration, these options are on the top level, not part of a dictionary.
 For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_`.
 
-### HTTP API Configuration
-
-The HTTP API listener can be used both for submission and for debugging purposes.
-
-| Option              | Description                                                          |
-|---------------------|----------------------------------------------------------------------|
-| listen              | Address to bind to, port included. (Example: `localhost:5680`)       |
-| debug-password      | Password expected via HTTP Basic Authentication for debug endpoints. |
-| debug-password_file | `debug-password` in a file.                                          |
-
 ### Icinga Web 2
 
-The `icingaweb2-url` is expected to point to the base directory of your Icinga Web 2 installation,
+The `icingaweb2_url` is expected to point to the base directory of your Icinga Web 2 installation,
 i.e., `https://example.com/icingaweb2/`, to be used for URL creation.
 
 ### Channels Directory
 
-All available Icinga Notifications channels should reside in the `channels-dir` directory.
+All available Icinga Notifications channels should reside in the `channels_dir` directory.
 For a package installation, the default will point to the correct location and must not be changed.
 
 This directory should be `/usr/libexec/icinga-notifications/channels` on systems that follow the Filesystem Hierarchy Standard.
 It may also be `/usr/lib/icinga-notifications/channels`, depending on the operating system conventions.
+
+## HTTP API Configuration
+
+Configuration of the HTTP API listener for event submission and debugging endpoints.
+
+For YAML configuration, the options are part of the `listener` section.
+For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_LISTENER_`.
+
+| Option              | Description                                                          |
+|---------------------|----------------------------------------------------------------------|
+| address             | Address to bind to, port included. (Example: `localhost:5680`)       |
+| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints. |
+| debug_password_file | `debug_password` in a file.                                          |
 
 ## Database Configuration
 

--- a/doc/04-Upgrading.md
+++ b/doc/04-Upgrading.md
@@ -61,6 +61,56 @@ Afterwards, restart Icinga Notifications.
 systemctl start icinga-notifications
 ```
 
+## Upgrading to Icinga Notifications v1.0
+
+This Icinga Notifications release is the first stable release of this project. It includes a database schema upgrade,
+which is required to be applied before starting the new version. Please follow the steps in the previous section to
+apply the schema upgrade. Apart from the schema upgrade, there are also some configuration changes, which are described
+in the [configuration changes section](#configuration-changes) below.
+
+### Schema
+
+Something about the schema upgrade.
+
+### Configuration Changes
+
+Starting with version v1.0, the Icinga Notifications configuration options have been restructured.
+Specifically, the `listen`, `debug-password`, and `debug-password_file` global options have been moved under a new
+`listener` section. If you are upgrading to version v1.0 from an earlier version, you will need to update your existing
+configuration file to reflect this change. Also, the `debug-password`, `debug-password_file`, and `listen` options have
+been renamed to `debug_password`, `debug_password_file`, and `address` respectively. Last but not least, the
+`icingaweb2-url` and `channels-dir` global options have been renamed to `icingaweb2_url` and `channels_dir` as well.
+
+!!! info
+
+    If you're using environment variables to set these options, you will need to update the environment variable names
+    accordingly. For example, `ICINGA_NOTIFICATIONS_LISTEN` should be changed to `ICINGA_NOTIFICATIONS_LISTENER_ADDRESS`.
+
+Please make sure to update your configuration file accordingly to ensure that Icinga Notifications continues to
+function properly after the upgrade. Below is an example of how to update your configuration file usually located
+at `/etc/icinga-notifications/config.yml`.
+
+```yaml
+# Before (pre-v1.0)
+
+listen: "localhost:5680"
+debug-password: "my-debug-password"
+#debug-password_file: "/path/to/debug-password-file"
+
+icingaweb2-url: http://localhost/icingaweb2
+channels-dir: /usr/libexec/icinga-notifications/channels
+
+# After (v1.0 and later)
+
+icingaweb2_url: http://localhost/icingaweb2
+channels_dir: /usr/libexec/icinga-notifications/channels
+
+listener:
+  address: "localhost:5680"
+  debug_password: "my-debug-password"
+  #debug_password_file: "/path/to/debug-password-file"
+```
+
 ## Upgrading to Icinga Notifications v0.2.0
 
 This Icinga Notifications release moves the Icinga event source from Icinga 2 to Icinga DB.

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -18,13 +18,20 @@ const (
 
 // Listener defines the configuration for the Icinga Notifications API listener.
 type Listener struct {
-	Addr              string `yaml:"address" env:"ADDRESS" default:"localhost:5680"`
-	DebugPassword     string `yaml:"debug_password" env:"DEBUG_PASSWORD"`
-	DebugPasswordFile string `yaml:"debug_password_file" env:"DEBUG_PASSWORD_FILE"`
+	Addr              string           `yaml:"address" env:"ADDRESS" default:"localhost:5680"`
+	DebugPassword     string           `yaml:"debug_password" env:"DEBUG_PASSWORD"`
+	DebugPasswordFile string           `yaml:"debug_password_file" env:"DEBUG_PASSWORD_FILE"`
+	TLSOptions        config.ServerTLS `yaml:",inline"`
 }
 
 func (l *Listener) Validate() error {
-	return config.LoadPasswordFile(&l.DebugPassword, l.DebugPasswordFile)
+	if err := config.LoadPasswordFile(&l.DebugPassword, l.DebugPasswordFile); err != nil {
+		return err
+	}
+	if err := l.TLSOptions.Validate(); err != nil {
+		return err
+	}
+	return nil
 }
 
 type ConfigFile struct {

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -16,14 +16,23 @@ const (
 	ExitFailure = 1
 )
 
+// Listener defines the configuration for the Icinga Notifications API listener.
+type Listener struct {
+	Addr              string `yaml:"address" env:"ADDRESS" default:"localhost:5680"`
+	DebugPassword     string `yaml:"debug_password" env:"DEBUG_PASSWORD"`
+	DebugPasswordFile string `yaml:"debug_password_file" env:"DEBUG_PASSWORD_FILE"`
+}
+
+func (l *Listener) Validate() error {
+	return config.LoadPasswordFile(&l.DebugPassword, l.DebugPasswordFile)
+}
+
 type ConfigFile struct {
-	Listen            string          `yaml:"listen" env:"LISTEN" default:"localhost:5680"`
-	DebugPassword     string          `yaml:"debug-password" env:"DEBUG_PASSWORD"`
-	DebugPasswordFile string          `yaml:"debug-password_file" env:"DEBUG_PASSWORD_FILE"`
-	ChannelsDir       string          `yaml:"channels-dir" env:"CHANNELS_DIR"`
-	Icingaweb2URL     string          `yaml:"icingaweb2-url" env:"ICINGAWEB2_URL"`
-	Database          database.Config `yaml:"database" envPrefix:"DATABASE_"`
-	Logging           logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
+	ChannelsDir   string          `yaml:"channels_dir" env:"CHANNELS_DIR"`
+	Icingaweb2URL string          `yaml:"icingaweb2_url" env:"ICINGAWEB2_URL"`
+	Listener      Listener        `yaml:"listener" envPrefix:"LISTENER_"`
+	Database      database.Config `yaml:"database" envPrefix:"DATABASE_"`
+	Logging       logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
 }
 
 // SetDefaults implements the defaults.Setter interface.
@@ -36,7 +45,7 @@ func (c *ConfigFile) SetDefaults() {
 // Validate implements the config.Validator interface.
 // Validates the entire daemon configuration on daemon startup.
 func (c *ConfigFile) Validate() error {
-	if err := config.LoadPasswordFile(&c.DebugPassword, c.DebugPasswordFile); err != nil {
+	if err := c.Listener.Validate(); err != nil {
 		return err
 	}
 	if err := c.Database.Validate(); err != nil {

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -96,7 +96,16 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 // An error is returned in every case except for a gracefully context-based shutdown without hitting the time limit.
 func (l *Listener) Run(ctx context.Context) error {
 	conf := daemon.Config().Listener
-	l.logger.Infof("Starting listener on http://%s", conf.Addr)
+	tlsConfig, err := conf.TLSOptions.MakeConfig()
+	if err != nil {
+		return err
+	}
+
+	var https string
+	if conf.TLSOptions.Enable {
+		https = "s"
+	}
+	l.logger.Infof("Starting listener on http%s://%s", https, conf.Addr)
 
 	stdlogger, err := zap.NewStdLogAt(l.logger.Desugar(), zap.ErrorLevel)
 	if err != nil {
@@ -106,6 +115,7 @@ func (l *Listener) Run(ctx context.Context) error {
 	server := &http.Server{
 		Addr:        conf.Addr,
 		Handler:     l,
+		TLSConfig:   tlsConfig,
 		ReadTimeout: 10 * time.Second,
 		IdleTimeout: 30 * time.Second,
 		// Redirect the standard library's HTTP server error log to our logger with error level because these
@@ -115,7 +125,14 @@ func (l *Listener) Run(ctx context.Context) error {
 
 	serverErr := make(chan error)
 	go func() {
-		serverErr <- server.ListenAndServe()
+		if conf.TLSOptions.Enable {
+			// We've already created the TLS config for the server, so we can pass empty strings
+			// for certFile and keyFile, which makes ListenAndServeTLS use the TLS config directly
+			// instead of trying to load certs from files.
+			serverErr <- server.ListenAndServeTLS("", "")
+		} else {
+			serverErr <- server.ListenAndServe()
+		}
 	}()
 
 	select {

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -123,7 +123,7 @@ func (l *Listener) Run(ctx context.Context) error {
 		ErrorLog: stdlogger,
 	}
 
-	serverErr := make(chan error)
+	serverErr := make(chan error, 1)
 	go func() {
 		if conf.TLSOptions.Enable {
 			// We've already created the TLS config for the server, so we can pass empty strings

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -62,10 +62,10 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 //
 // An error is returned in every case except for a gracefully context-based shutdown without hitting the time limit.
 func (l *Listener) Run(ctx context.Context) error {
-	listenAddr := daemon.Config().Listen
-	l.logger.Infof("Starting listener on http://%s", listenAddr)
+	conf := daemon.Config().Listener
+	l.logger.Infof("Starting listener on http://%s", conf.Addr)
 	server := &http.Server{
-		Addr:        listenAddr,
+		Addr:        conf.Addr,
 		Handler:     l,
 		ReadTimeout: 10 * time.Second,
 		IdleTimeout: 30 * time.Second,
@@ -226,7 +226,7 @@ func (l *Listener) GetIncidents(w http.ResponseWriter, r *http.Request) {
 // configured or the supplied password is incorrect, it sends an error code and does not redirect the request.
 func (l *Listener) requireDebugAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		expectedPassword := daemon.Config().DebugPassword
+		expectedPassword := daemon.Config().Listener.DebugPassword
 		if expectedPassword == "" {
 			w.WriteHeader(http.StatusForbidden)
 			_, _ = fmt.Fprintln(w, "config dump disabled, no debug-password set in config")

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -254,6 +254,7 @@ func (l *Listener) GetIncidents(w http.ResponseWriter, r *http.Request) {
 			inc.Unlock()
 		}
 	}
+	w.Header().Add("Content-Type", "application/json")
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -298,6 +299,7 @@ func (l *Listener) DumpConfig(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "GET required")
 		return
 	}
+	w.Header().Add("Content-Type", "application/json")
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -311,6 +313,7 @@ func (l *Listener) DumpIncidents(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "GET required")
 		return
 	}
+	w.Header().Add("Content-Type", "application/json")
 
 	incidents := incident.GetCurrentIncidents()
 	encodedIncidents := make(map[int64]json.RawMessage)
@@ -374,6 +377,7 @@ func (l *Listener) DumpRules(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "GET required")
 		return
 	}
+	w.Header().Add("Content-Type", "application/json")
 
 	l.runtimeConfig.RLock()
 	defer l.runtimeConfig.RUnlock()

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -64,11 +64,20 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (l *Listener) Run(ctx context.Context) error {
 	conf := daemon.Config().Listener
 	l.logger.Infof("Starting listener on http://%s", conf.Addr)
+
+	stdlogger, err := zap.NewStdLogAt(l.logger.Desugar(), zap.ErrorLevel)
+	if err != nil {
+		return err
+	}
+
 	server := &http.Server{
 		Addr:        conf.Addr,
 		Handler:     l,
 		ReadTimeout: 10 * time.Second,
 		IdleTimeout: 30 * time.Second,
+		// Redirect the standard library's HTTP server error log to our logger with error level because these
+		// errors are usually unexpected and indicate a problem with the server that should be investigated.
+		ErrorLog: stdlogger,
 	}
 
 	serverErr := make(chan error)

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -21,6 +21,22 @@ import (
 	"time"
 )
 
+// responseWriter is a wrapper around [http.ResponseWriter] that captures the status code written to the response.
+//
+// Note: This struct satisfies only the [http.ResponseWriter] interface, but not the optional [http.Flusher],
+// [http.Hijacker], and [http.Pusher] interfaces. If the underlying [http.ResponseWriter] implements any of
+// these interfaces, the caller must use the [http.ResponseWriter] directly to access them.
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+// WriteHeader captures the status code and writes it to the underlying [ResponseWriter].
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.status = status
+	rw.ResponseWriter.WriteHeader(status)
+}
+
 type Listener struct {
 	db            *database.DB
 	logger        *logging.Logger
@@ -50,9 +66,26 @@ func NewListener(db *database.DB, runtimeConfig *config.RuntimeConfig, logs *log
 	return l
 }
 
+// ServeHTTP implements the [http.Handler] interface for the Listener, allowing it to be used as an actual HTTP handler.
+//
+// It just sets a Server header and then delegates the request handling to the internal [http.ServeMux].
+// The status code of the response is captured and logged together with other request information after
+// the request has been handled.
 func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Server", "icinga-notifications/"+internal.Version.Version)
-	l.mux.ServeHTTP(rw, req)
+	// Default to OK, so that if a handler just writes to the response without explicitly setting a status,
+	// we still log the request as successful instead of logging it with a misleading 0 status code.
+	crw := &responseWriter{ResponseWriter: rw, status: http.StatusOK}
+	l.mux.ServeHTTP(crw, req)
+
+	// We're not using a `defer` here because we don't actually care logging these info if the handler panics,
+	// so we want to let the panic propagate instead of logging a potentially misleading request log with OK status.
+	l.logger.Debugw("Handled request",
+		zap.String("method", req.Method),
+		zap.String("target_url", req.RequestURI),
+		zap.String("remote_addr", req.RemoteAddr),
+		zap.String("user_agent", req.UserAgent()),
+		zap.String("status", http.StatusText(crw.status)))
 }
 
 // Run the Listener's web server and block until the server has finished.


### PR DESCRIPTION
This PR adds support for HTTPs for the HTTP listener. To accomplish this, a new `listener` block is added to the configuration file, which wraps all the HTTP listener related configuration options including the new TLS related settings. This allows for a more organized and modular configuration structure, but also means that the existing configuration files will need to be updated to reflect this change. In other words, this breaks backward compatibility with existing configuration files, and users will need to update their configuration files to use the new `listener` block structure.

Apart from that, the internal HTTP server default error logger is now replaced with a custom logger derived from the listener's logger, which provides better integration with our logging system and allows for more consistent logging of errors related to the HTTP listener. I've also added a new debug log in the `ServeHTTP` method to log incoming requests, which can be helpful for debugging and monitoring purposes.

```bash
2026-05-28T11:21:27.703+0200	INFO	listener	Starting listener on https://:5680
2026-05-28T11:21:30.431+0200	ERROR	listener	http: TLS handshake error from 127.0.0.1:57087: tls: client didn't provide a certificate
2026-05-28T11:21:52.499+0200	ERROR	listener	http: TLS handshake error from 127.0.0.1:57108: tls: failed to verify certificate: x509: “notifications.devlab.com” certificate is not standards compliant
2026-05-28T11:23:36.266+0200	DEBUG	listener	Handled request	{"method": "GET", "target_url": "/debug/dump-rules?pretty=1", "remote_addr": "127.0.0.1:57195", "user_agent": "curl/8.7.1", "status": "OK"}
2026-05-28T11:23:49.355+0200	DEBUG	listener	Handled request	{"method": "GET", "target_url": "/debug/dump-rules?pretty=1", "remote_addr": "127.0.0.1:57199", "user_agent": "curl/8.7.1", "status": "OK"}
2026-05-28T11:23:53.570+0200	DEBUG	listener	Handled request	{"method": "GET", "target_url": "/debug/dump-rules?pretty=1", "remote_addr": "127.0.0.1:57200", "user_agent": "curl/8.7.1", "status": "OK"}
2026-05-28T11:23:59.104+0200	DEBUG	listener	Handled request	{"method": "GET", "target_url": "/debug/dump-rules?pretty=1", "remote_addr": "127.0.0.1:57201", "user_agent": "curl/8.7.1", "status": "OK"}
2026-05-28T11:24:03.428+0200	DEBUG	listener	Handled request	{"method": "GET", "target_url": "/debug/dump-rules?pretty=1", "remote_addr": "127.0.0.1:57202", "user_agent": "curl/8.7.1", "status": "OK"}
```

```bash
$ curl -kvu ':icinga' 'https://127.0.0.1:5680/debug/dump-rules?pretty=1'
*   Trying 127.0.0.1:5680...
* Connected to 127.0.0.1 (127.0.0.1) port 5680
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Request CERT (13):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Certificate (11):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=DE; ST=Bayern; L=Nuremberg; O=Icinga GmbH; OU=Monitoring; CN=notifications.devlab.com
*  start date: May 27 10:09:09 2026 GMT
*  expire date: May 24 10:09:09 2036 GMT
*  issuer: C=DE; ST=Bayern; L=Nuremberg; O=Icinga GmbH; OU=Monitoring; CN=notifications.devlab.com
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/2
* Server auth using Basic with user ''
* [HTTP/2] [1] OPENED stream for https://127.0.0.1:5680/debug/dump-rules?pretty=1
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: 127.0.0.1:5680]
* [HTTP/2] [1] [:path: /debug/dump-rules?pretty=1]
* [HTTP/2] [1] [authorization: Basic OmljaW5nYQ==]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /debug/dump-rules?pretty=1 HTTP/2
> Host: 127.0.0.1:5680
> Authorization: Basic OmljaW5nYQ==
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: application/json
< server: icinga-notifications/0.2.0
< content-length: 1752
< date: Thu, 28 May 2026 09:24:03 GMT
<
{
  "1": {
    "ChangedAt": 10000,
    "Deleted": false,
---
```

## Requires
- https://github.com/Icinga/icinga-go-library/pull/204

resolves #388