### PR TITLE
Drop `client_auth` config option

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -34,19 +34,8 @@ listener:
 
   # Set the path to a CA certificate or PEM-encoded multiline string to enable client certificate authentication.
   #
-  # If the `client_auth` option is set to 'VerifyClientCertIfGiven' or 'RequireAndVerifyClientCert', this option
-  # must be set to a valid CA certificate to verify client certificates against. Otherwise, it's optional and can
-  # be left unset.
+  # Required if TLS is enabled to be able to verify client certificate if the client provides one.
   #ca: /path/to/ca.crt
-
-  # Set the client authentication mode for the Icinga Notifications HTTP listener.
-  #
-  # This can be set to 'NoClientCert' to disable client certificate authentication, 'RequestClientCert' to
-  # request but not require client certificates, 'RequireAnyClientCert' to require any client cert without
-  # verification, 'VerifyClientCertIfGiven' to verify client certificates if provided but not require them,
-  # or 'RequireAndVerifyClientCert' to always require and verify client certificates. If not set, defaults
-  # to 'NoClientCert'.
-  #client_auth: NoClientCert
 
 # Connection configuration for the database where Icinga Notifications stores configuration and historical data.
 # This is also the database used in Icinga Notifications Web to view and work with the data.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -47,27 +47,15 @@ Configuration of the HTTP API listener for event submission and debugging endpoi
 For YAML configuration, the options are part of the `listener` section.
 For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_LISTENER_`.
 
-| Option              | Description                                                                       |
-|---------------------|-----------------------------------------------------------------------------------|
-| address             | Address to bind to, port included. (Example: `localhost:5680`)                    |
-| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints.              |
-| debug_password_file | `debug_password` in a file.                                                       |
-| tls                 | **Optional.** Whether to require TLS for the listener. Defaults to `false`.       |
-| cert                | **Optional.** Path to TLS server certificate. Required if `tls` is set to `true`. |
-| key                 | **Optional.** Path to the TLS private key. Required if `tls` is `true`.           |
-| ca                  | **Optional.** Path to TLS CA cert to verify client certificates.                  |
-| client_auth         | **Optional.** TLS client authentication mode. Defaults to `NoClientCert`.         |
-
-!!! info
-
-    When the `client_auth` option is set to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`, the `ca`
-    option must be set to a valid TLS CA cert to verify client certificates against. Otherwise, it's optional and
-    can be left out.
-
-    The TLS `client_auth` option can either be set to `NoClientCert` to disable client authentication,
-    `RequestClientCert` to request but not require and verify client certificates if provided, `RequireAnyClientCert`
-    to require any client certificate without verification, `VerifyClientCertIfGiven` to verify client certificates if
-    provided, or `RequireAndVerifyClientCert` to always require and verify client certificates.
+| Option              | Description                                                                                    |
+|---------------------|------------------------------------------------------------------------------------------------|
+| address             | Address to bind to, port included. (Example: `localhost:5680`)                                 |
+| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints.                           |
+| debug_password_file | `debug_password` in a file.                                                                    |
+| tls                 | **Optional.** Whether to require TLS for the listener. Defaults to `false`.                    |
+| cert                | **Optional.** Path to TLS server certificate. Required if `tls` is enabled.                    |
+| key                 | **Optional.** Path to the TLS private key. Required if `tls` is enabled.                       |
+| ca                  | **Optional.** Path to TLS CA cert/bundle to verify client certs. Required if `tls` is enabled. |
 
 ## Database Configuration
 

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -1,14 +1,16 @@
 package daemon
 
 import (
+	"crypto/tls"
 	"errors"
+	"os"
+
 	"github.com/creasty/defaults"
 	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/icinga/icinga-go-library/utils"
 	"github.com/icinga/icinga-notifications/internal"
-	"os"
 )
 
 const (
@@ -21,17 +23,31 @@ type Listener struct {
 	Addr              string           `yaml:"address" env:"ADDRESS" default:"localhost:5680"`
 	DebugPassword     string           `yaml:"debug_password" env:"DEBUG_PASSWORD"`
 	DebugPasswordFile string           `yaml:"debug_password_file" env:"DEBUG_PASSWORD_FILE"`
-	TLSOptions        config.ServerTLS `yaml:",inline"`
+	TLSOptions        config.TLSCommon `yaml:",inline"`
 }
 
 func (l *Listener) Validate() error {
 	if err := config.LoadPasswordFile(&l.DebugPassword, l.DebugPasswordFile); err != nil {
 		return err
 	}
-	if err := l.TLSOptions.Validate(); err != nil {
-		return err
+
+	if l.TLSOptions.Enable {
+		if l.TLSOptions.Ca == "" {
+			return errors.New("missing CA certificate")
+		}
+
+		tlsOpts := &config.ServerTLS{TLSCommon: l.TLSOptions, ClientAuth: config.TlsClientAuthType(tls.VerifyClientCertIfGiven)}
+		if err := tlsOpts.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// GetTlsConfig returns a *[tls.Config] based on the TLS options specified in the Listener configuration.
+func (l *Listener) GetTlsConfig() (*tls.Config, error) {
+	tlsOpts := &config.ServerTLS{TLSCommon: l.TLSOptions, ClientAuth: config.TlsClientAuthType(tls.VerifyClientCertIfGiven)}
+	return tlsOpts.MakeConfig()
 }
 
 type ConfigFile struct {

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -96,7 +96,7 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 // An error is returned in every case except for a gracefully context-based shutdown without hitting the time limit.
 func (l *Listener) Run(ctx context.Context) error {
 	conf := daemon.Config().Listener
-	tlsConfig, err := conf.TLSOptions.MakeConfig()
+	tlsConfig, err := conf.GetTlsConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead, we'll always be using hard-coded `tls.VerifyClientCertIfGiven` and make the `ca` option required if TLS is enabled. This is based on a discussion with @nilmerg, who doesn't want to make the `client_auth` user configurable with all its available options.