### PR TITLE
Schema: Remove redundant semicolons

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -21,8 +21,7 @@ BEGIN
         SET error_message = CONCAT('Schema version mismatch: expected ', expected_version, ', got ', actual_version, '. Please apply all previous upgrade scripts in order before applying this one.');
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_message;
     END IF;
-END;
-//
+END //
 DELIMITER ;
 
 CREATE TABLE available_channel_type (

--- a/schema/mysql/upgrades/003.sql
+++ b/schema/mysql/upgrades/003.sql
@@ -18,8 +18,7 @@ BEGIN
         SET error_message = CONCAT('Schema version mismatch: expected ', expected_version, ', got ', actual_version, '. Please apply all previous upgrade scripts in order before applying this one.');
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_message;
     END IF;
-END;
-//
+END //
 DELIMITER ;
 
 CREATE TABLE notifications_schema (


### PR DESCRIPTION
The mysql schema uses a `;` before the procedure delimiter, resulting in an empty statement.
This is harmless for the mysql client, but causes problems for the notifications-web tests, so the redundant semicolon is removed from the schema and for consistency from the upgrade file as well.