### PR TITLE
Enhance event URL completion

### DIFF
--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -160,7 +160,7 @@ func (c *Channel) Restart(logger *zap.SugaredLogger) {
 }
 
 // Notify prepares and sends the notification request, returns a non-error on fails, nil on success
-func (c *Channel) Notify(contact *recipient.Contact, i contracts.Incident, ev *event.Event, icingaweb2Url string) error {
+func (c *Channel) Notify(contact *recipient.Contact, i contracts.Incident, ev *event.Event, icingaweb2Url *url.URL) error {
 	p := c.getPlugin()
 	if p == nil {
 		return errors.New("plugin could not be started")
@@ -171,8 +171,7 @@ func (c *Channel) Notify(contact *recipient.Contact, i contracts.Incident, ev *e
 		contactStruct.Addresses = append(contactStruct.Addresses, &plugin.Address{Type: addr.Type, Address: addr.Address})
 	}
 
-	baseUrl, _ := url.Parse(icingaweb2Url)
-	incidentUrl := baseUrl.JoinPath("/notifications/incident")
+	incidentUrl := icingaweb2Url.JoinPath("/notifications/incident")
 	incidentUrl.RawQuery = fmt.Sprintf("id=%d", i.ID())
 	object := i.IncidentObject()
 

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/creasty/defaults"
@@ -56,6 +58,12 @@ type ConfigFile struct {
 	Listener      Listener        `yaml:"listener" envPrefix:"LISTENER_"`
 	Database      database.Config `yaml:"database" envPrefix:"DATABASE_"`
 	Logging       logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
+
+	// IcingaWeb2UrlParsed holds the parsed Icinga Web 2 URL after validation of the config file.
+	//
+	// This field is not part of the YAML config and is only populated after successful validation.
+	// The resulting URL always ends with a trailing slash, making it easier to resolve relative paths against it.
+	IcingaWeb2UrlParsed *url.URL
 }
 
 // SetDefaults implements the defaults.Setter interface.
@@ -77,6 +85,23 @@ func (c *ConfigFile) Validate() error {
 	if err := c.Logging.Validate(); err != nil {
 		return err
 	}
+
+	if c.Icingaweb2URL == "" {
+		return errors.New("icingaweb2_url must be set")
+	}
+
+	parsedUrl, err := url.Parse(c.Icingaweb2URL)
+	if err != nil {
+		return fmt.Errorf("invalid icingaweb2_url: %w", err)
+	}
+
+	if !parsedUrl.IsAbs() {
+		return errors.New("icingaweb2_url must be an absolute URL")
+	}
+
+	parsedUrl.RawQuery = "" // Ignore query params if provided, as they are not relevant for resolving event URLs
+	// Ensure the URL ends with a trailing slash for easier resolution of relative paths.
+	c.IcingaWeb2UrlParsed = parsedUrl.JoinPath("/")
 
 	return nil
 }

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -43,19 +43,25 @@ type Event struct {
 	evaluatedRelations map[string]jsonpath.NodeList
 }
 
-// CompleteURL prefixes the URL with the given Icinga Web 2 base URL unless it already carries a URL or is empty.
-func (e *Event) CompleteURL(icingaWebBaseUrl string) {
+// CompleteURL returns the complete URL for this event by combining the Icinga Web 2 URL with the event's own url field.
+//
+// If the event's url field is an absolute URL, is empty, or it can't be URL parsed, then this method is a no-op.
+// Otherwise, it is resolved against the provided Icinga Web 2 URL to form a complete URL.
+func (e *Event) CompleteURL(icingaWebBaseUrl *url.URL) {
 	if e.URL == "" {
 		return
 	}
 
-	if !strings.HasSuffix(icingaWebBaseUrl, "/") {
-		icingaWebBaseUrl += "/"
+	u, err := url.Parse(strings.TrimLeft(e.URL, "/"))
+	if err != nil {
+		return // leave it as is if it cannot be parsed as a URL
 	}
 
-	u, err := url.Parse(e.URL)
-	if err != nil || u.Scheme == "" {
-		e.URL = icingaWebBaseUrl + e.URL
+	if !u.IsAbs() {
+		// Actually, the Icinga Web 2 base url should always contain the trailing slash, but just in
+		// case it doesn't, make sure to add it before resolving the event URL against it to avoid
+		// losing the last path segment of the base url.
+		e.URL = icingaWebBaseUrl.JoinPath("/").ResolveReference(u).String()
 	}
 }
 

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"net/url"
 	"testing"
 
 	baseEv "github.com/icinga/icinga-go-library/notifications/event"
@@ -12,6 +13,55 @@ import (
 
 func TestEvent(t *testing.T) {
 	t.Parallel()
+
+	t.Run("CompleteURL", func(t *testing.T) {
+		t.Parallel()
+
+		baseUrl, err := url.Parse("https://example.com/icingaweb")
+		require.NoError(t, err)
+
+		testCases := []struct {
+			name     string
+			eventURL string
+			expected string
+		}{
+			{
+				name:     "Absolute URL",
+				eventURL: "https://example.org/path/123",
+				expected: "https://example.org/path/123",
+			},
+			{
+				name:     "Relative URL With Leading Slash",
+				eventURL: "/icingadb/host?name=testhost",
+				expected: "https://example.com/icingaweb/icingadb/host?name=testhost",
+			},
+			{
+				name:     "Relative URL Without Leading slash",
+				eventURL: "icingadb/service?host.name=testhost&name=testservice",
+				expected: "https://example.com/icingaweb/icingadb/service?host.name=testhost&name=testservice",
+			},
+			{
+				name:     "Invalid URL",
+				eventURL: "http://[invalid-url",
+				expected: "http://[invalid-url",
+			},
+			{
+				name:     "Empty URL",
+				eventURL: "",
+				expected: "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				ev := &Event{Event: baseEv.Event{URL: tc.eventURL}}
+				ev.CompleteURL(baseUrl)
+				assert.Equal(t, tc.expected, ev.URL)
+			})
+		}
+	})
 
 	t.Run("ExtractMissingRelations", func(t *testing.T) {
 		t.Parallel()

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -622,8 +622,7 @@ func (i *Incident) notifyContact(contact *recipient.Contact, ev *event.Event, ch
 	i.logger.Infow(fmt.Sprintf("Notify contact %q via %q of type %q", contact.FullName, ch.Name, ch.Type),
 		zap.Int64("channel_id", chID), zap.String("event_type", ev.Type.String()))
 
-	err := ch.Notify(contact, i, ev, daemon.Config().Icingaweb2URL)
-	if err != nil {
+	if err := ch.Notify(contact, i, ev, daemon.Config().IcingaWeb2UrlParsed); err != nil {
 		i.logger.Errorw("Failed to send notification via channel plugin", zap.String("type", ch.Type), zap.Error(err))
 		return err
 	}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -197,7 +197,7 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ev.CompleteURL(daemon.Config().Icingaweb2URL)
+	ev.CompleteURL(daemon.Config().IcingaWeb2UrlParsed)
 	ev.Time = time.Now()
 	ev.SourceId = src.ID
 	if ev.Type == baseEv.TypeUnknown {


### PR DESCRIPTION
Instead of using string concatenation to build the final event URL as it's currently done, we can use the `url` package to create a more robust and error-resistant URL construction. Thus, this PR refactors the code a bit to utilize that package, which should help prevent issues with malformed URLs as described in the linked issue. To accomplish this, the daemon `ConfigFile` struct has been updated to include a parsed `url.URL` instance of the Icinga Web 2 base URL, which is then used to construct the final event and incident URLs in a more structured way. I've also added a basic test cases for the `Event.CompleteURL` method to ensure that the URL construction works as expected.

fixes #435