### PR TITLE
Support source connection via http over unix sockets

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/okzk/sdnotify"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -34,6 +35,7 @@ func main() {
 }
 
 func run() int {
+	unix.Umask(0077) // Ensure Unix sockets are created with 0600 by default, denying group/other access.
 	daemon.ParseFlagsAndConfig()
 	conf := daemon.Config()
 
@@ -91,16 +93,26 @@ func run() int {
 		}
 	})
 
-	eg.Go(func() error {
-		err := listener.NewListener(db, runtimeConfig, logs).Run(ctx)
-		if err == nil || errors.Is(err, context.Canceled) {
-			logger.Info("Listener has finished")
-			return nil
-		} else {
-			logger.Errorf("Listener has finished with an error: %+v", err)
-			return err
-		}
-	})
+	listenerConf := daemon.Config().Listener
+	makeListeners := func(useSocket bool) {
+		eg.Go(func() error {
+			err := listener.NewListener(db, runtimeConfig, logs, useSocket).Run(ctx)
+			if err == nil || errors.Is(err, context.Canceled) {
+				logger.Info("Listener has finished")
+				return nil
+			} else {
+				logger.Errorf("Listener has finished with an error: %+v", err)
+				return err
+			}
+		})
+	}
+
+	if listenerConf.Socket != "" {
+		makeListeners(true)
+	}
+	if listenerConf.Addr != "" {
+		makeListeners(false)
+	}
 
 	eg.Go(func() error {
 		logger := logs.GetChildLogger("event-queue")

--- a/config.example.yml
+++ b/config.example.yml
@@ -14,6 +14,20 @@ listener:
   # Defaults to "localhost:5680".
   #address: "localhost:5680"
 
+  # Path to a Unix domain socket for local sources to submit events.
+  # When set, sources connecting via this socket identify themselves by username only; no password is required.
+  # This transport is recommended when the source and daemon run on the same host. Leave unset (the default) to disable.
+  #socket: "/run/icinga/icinga-notifications.sock"
+
+  # Permission bits for the Unix socket file, given as an octal. Defaults to "0660".
+  # To restrict access to a specific OS group, set socket_group and leave this at "0660".
+  # Note: each source requires its own OS user, so "0600" (owner-only) would limit the socket to a single source.
+  #socket_mode: "0660"
+
+  # OS group to assign to the Unix socket file. When socket_mode grants group access (e.g. "0660"),
+  # this controls which group gets that access. Defaults to the primary group of the daemon process.
+  #socket_group: "icinga-notifications"
+
   # Set credentials for all the HTTP debug endpoints. This can be set either directly or read from a file.
   # Setting both options is not allowed and will result in a configuration error. If both options are left
   # unset, the debug endpoints will be disabled and won't be accessible at all.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -43,19 +43,34 @@ It may also be `/usr/lib/icinga-notifications/channels`, depending on the operat
 ## HTTP API Configuration
 
 Configuration of the HTTP API listener for event submission and debugging endpoints.
+Icinga Notifications can run a TCP listener, a Unix socket listener, or both simultaneously.
+When neither `address` nor `socket` is configured, the TCP listener defaults to `localhost:5680`.
+TLS options apply only to the TCP listener.
+
+When a Unix socket is configured, Icinga Notifications identifies connecting processes by their OS user,
+and matches the OS username against the source's configured username. No password or HTTP Basic Auth is involved.
 
 For YAML configuration, the options are part of the `listener` section.
 For environment variables, each option is prefixed with `ICINGA_NOTIFICATIONS_LISTENER_`.
 
-| Option              | Description                                                                                    |
-|---------------------|------------------------------------------------------------------------------------------------|
-| address             | Address to bind to, port included. (Example: `localhost:5680`)                                 |
-| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints.                           |
-| debug_password_file | `debug_password` in a file.                                                                    |
-| tls                 | **Optional.** Whether to require TLS for the listener. Defaults to `false`.                    |
-| cert                | **Optional.** Path to TLS server certificate. Required if `tls` is enabled.                    |
-| key                 | **Optional.** Path to the TLS private key. Required if `tls` is enabled.                       |
-| ca                  | **Optional.** Path to TLS CA cert/bundle to verify client certs. Required if `tls` is enabled. |
+| Option              | Description                                                                                                |
+|---------------------|------------------------------------------------------------------------------------------------------------|
+| address             | **Optional.** TCP address to bind to. Defaults to `localhost:5680` when `socket` is not set.               |
+| socket              | **Optional.** Path to a Unix domain socket for local event submission.                                     |
+| socket_mode         | **Optional.** Permission bits for the Unix socket file, as an octal. Defaults to `0660`.                   |
+| socket_group        | **Optional.** OS group to assign to the Unix socket file. Defaults to Icinga Notifications' primary group. |
+| debug_password      | Password expected via HTTP Basic Authentication for debug endpoints.                                       |
+| debug_password_file | `debug_password` in a file.                                                                                |
+| tls                 | **Optional.** Whether to require TLS for the TCP listener. Defaults to `false`.                            |
+| cert                | **Optional.** Path to TLS server certificate. Required if `tls` is enabled.                                |
+| key                 | **Optional.** Path to the TLS private key. Required if `tls` is enabled.                                   |
+| ca                  | **Optional.** Path to TLS CA cert/bundle to verify client certs. Required if `tls` is enabled.             |
+
+!!! important
+
+    The socket permissions restricts who can access the Unix socket.
+    A process can only submit events for sources whose configured listener_username matches the process's OS username.
+    So each source requires its own OS user; set `0600` (owner-only) would limit the socket to a single source.
 
 ## Database Configuration
 

--- a/doc/20-HTTP-API.md
+++ b/doc/20-HTTP-API.md
@@ -11,7 +11,18 @@ After creating a source in Icinga Notifications Web,
 the specified credentials can be used via HTTP Basic Authentication to submit a JSON-encoded
 [`Event`](https://github.com/Icinga/icinga-go-library/blob/main/notifications/event/event.go).
 
-The authentication is performed via HTTP Basic Authentication using the source's username and password.
+Authentication differs by transport:
+
+- **TCP:** HTTP Basic Authentication is used; both the source's username and password must match
+  the configured credentials.
+- **Unix socket:** The caller is identified automatically by their OS user. No HTTP Basic Auth or
+  password is involved.
+
+!!! important
+
+    A process connecting via the Unix socket can only submit events for sources whose configured
+    listener_username matches the process's OS username. Restrict socket access using `socket_mode` and
+    `socket_group` to limit which OS users can connect.
 
 !!! info
 
@@ -88,11 +99,19 @@ curl -v -u 'icingadb:insecureinsecure' -H 'X-Icinga-Reject-If-Relations-Incomple
 EOF
 ```
 
+To submit over a Unix socket instead, pass `--unix-socket /run/icinga/icinga-notifications.sock` to curl.
+No credentials are needed; the daemon identifies the caller by their OS user automatically.
+
+!!! info
+
+    curl must be executed as a user which is configured as listener_username of a source.
+
 ### Get Incidents
 
 A source can query the list of open incidents belonging to its objects using the `/incidents` HTTP API endpoint.
 
-The authentication is performed via HTTP Basic Authentication using the source's username and password.
+Authentication follows the same transport-specific rules as for event submission: TCP requires HTTP
+Basic Auth with username and password, while a Unix socket identifies the caller by their OS user.
 
 ```
 $ curl -u 'example:insecureinsecure' 'http://localhost:5680/incidents'
@@ -121,6 +140,8 @@ $ curl -u 'example:insecureinsecure' 'http://localhost:5680/incidents'
 There are multiple endpoints for dumping specific configurations.
 All of them are prefixed by `/debug`.
 To use those, the `debug-password` must be set and supplied via HTTP Basic Authentication next to an arbitrary username.
+Unlike event submission, the debug endpoints always require the password regardless of the transport; connecting via
+Unix socket does not bypass this check.
 
 ### Dump Config
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/icinga/icinga-notifications
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/creasty/defaults v1.8.0

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
+	"time"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/icinga/icinga-go-library/types"
@@ -13,8 +16,6 @@ import (
 	"github.com/icinga/icinga-notifications/internal/timeperiod"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
-	"sync"
-	"time"
 )
 
 // RuntimeConfig stores the runtime representation of the configuration present in the database.
@@ -190,6 +191,23 @@ func (r *RuntimeConfig) GetSourceFromCredentials(user, pass string, logger *logg
 	}
 
 	return src
+}
+
+// GetSourceByUsername looks up a Source by its listener username without verifying a password.
+//
+// This method is intended for connections over trusted transports such as Unix sockets, where the
+// transport itself provides the security guarantee that no password is required.
+func (r *RuntimeConfig) GetSourceByUsername(user string) *Source {
+	r.RLock()
+	defer r.RUnlock()
+
+	for _, src := range r.Sources {
+		if src.ListenerUsername.Valid && src.ListenerUsername.String == user {
+			return src
+		}
+	}
+
+	return nil
 }
 
 func (r *RuntimeConfig) fetchFromDatabase(ctx context.Context) error {

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/icinga/icinga-go-library/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSourceByUsername(t *testing.T) {
+	t.Parallel()
+
+	srcA := &Source{ListenerUsername: types.MakeString("icingadb")}
+	srcB := &Source{ListenerUsername: types.MakeString("icinga2")}
+	srcNoUser := &Source{} // ListenerUsername.Valid == false
+
+	rc := &RuntimeConfig{}
+	rc.Sources = map[int64]*Source{
+		1: srcA,
+		2: srcB,
+		3: srcNoUser,
+	}
+
+	tests := []struct {
+		name     string
+		username string
+		want     *Source
+	}{
+		{
+			name:     "KnownUsername1",
+			username: "icingadb",
+			want:     srcA,
+		},
+		{
+			name:     "KnownUsername2",
+			username: "icinga2",
+			want:     srcB,
+		},
+		{
+			name:     "UnknownUsername",
+			username: "unknown",
+			want:     nil,
+		},
+		{
+			name:     "EmptyUsername",
+			username: "",
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Same(t, tc.want, rc.GetSourceByUsername(tc.username))
+		})
+	}
+}

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -4,8 +4,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
+	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/creasty/defaults"
@@ -21,9 +24,27 @@ const (
 	ExitFailure = 1
 )
 
+// Mode is a Unix file permission mode parsed from an octal string in YAML or environment configuration.
+type Mode fs.FileMode
+
+// UnmarshalText implements [encoding.TextUnmarshaler] for Mode, parsing an octal string (e.g. "0660") into a file mode.
+func (m *Mode) UnmarshalText(text []byte) error {
+	parsedString, err := strconv.ParseUint(string(text), 8, 32)
+
+	if err != nil {
+		return fmt.Errorf("invalid socket_mode %q: expected an octal value like 0660: %w", text, err)
+	}
+	*m = Mode(parsedString)
+
+	return nil
+}
+
 // Listener defines the configuration for the Icinga Notifications API listener.
 type Listener struct {
-	Addr              string           `yaml:"address" env:"ADDRESS" default:"localhost:5680"`
+	Addr              string           `yaml:"address" env:"ADDRESS"`
+	Socket            string           `yaml:"socket" env:"SOCKET"`
+	SocketMode        *Mode            `yaml:"socket_mode" env:"SOCKET_MODE" default:"0660"`
+	SocketGroup       string           `yaml:"socket_group" env:"SOCKET_GROUP"`
 	DebugPassword     string           `yaml:"debug_password" env:"DEBUG_PASSWORD"`
 	DebugPasswordFile string           `yaml:"debug_password_file" env:"DEBUG_PASSWORD_FILE"`
 	TLSOptions        config.TLSCommon `yaml:",inline"`
@@ -32,6 +53,31 @@ type Listener struct {
 func (l *Listener) Validate() error {
 	if err := config.LoadPasswordFile(&l.DebugPassword, l.DebugPasswordFile); err != nil {
 		return err
+	}
+
+	if l.Socket != "" {
+		if mode := l.SocketMode; mode != nil && *mode > 0o777 {
+			return fmt.Errorf("the socket_mode \"%04o\" is too large (max 777)", mode)
+		} else if mode != nil && *mode&0o666 == 0 {
+			return fmt.Errorf(
+				"socket_mode \"%04o\" grants no read/write access; the socket cannot accept connections",
+				mode,
+			)
+		}
+
+		if groupName := l.SocketGroup; groupName != "" {
+			group, err := user.LookupGroup(groupName)
+			if err != nil {
+				return fmt.Errorf("cannot find group %q: %w", groupName, err)
+			}
+
+			if _, err = strconv.Atoi(group.Gid); err != nil {
+				return fmt.Errorf("cannot parse GID for group %q: %w", groupName, err)
+			}
+		}
+	} else if l.Addr == "" {
+		// Only set the default Address for TCP server if no socket path is provided
+		l.Addr = "localhost:5680"
 	}
 
 	if l.TLSOptions.Enable {

--- a/internal/daemon/config_test.go
+++ b/internal/daemon/config_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenerValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		listener        Listener
+		wantAddr        string
+		wantSocket      string
+		wantSocketMode  *Mode
+		wantSocketGroup string
+		wantErr         bool
+	}{
+		{
+			name:            "NoConnectionConfigured",
+			listener:        Listener{},
+			wantAddr:        "localhost:5680",
+			wantSocket:      "",
+			wantSocketGroup: "",
+		},
+		{
+			name:            "SocketOnly",
+			listener:        Listener{Socket: "/tmp/test.sock", SocketMode: new(Mode(0660))},
+			wantAddr:        "",
+			wantSocket:      "/tmp/test.sock",
+			wantSocketMode:  new(Mode(0660)),
+			wantSocketGroup: "",
+		},
+		{
+			name:            "AddrOnly",
+			listener:        Listener{Addr: "localhost:5681"},
+			wantAddr:        "localhost:5681",
+			wantSocket:      "",
+			wantSocketGroup: "",
+		},
+		{
+			name:            "AddrAndSocket",
+			listener:        Listener{Addr: "localhost:5681", Socket: "/tmp/test.sock", SocketMode: new(Mode(0660))},
+			wantAddr:        "localhost:5681",
+			wantSocket:      "/tmp/test.sock",
+			wantSocketMode:  new(Mode(0660)),
+			wantSocketGroup: "",
+		},
+		{
+			name:            "PermissiveSocketMode",
+			listener:        Listener{Socket: "/tmp/test.sock", SocketMode: new(Mode(0777))},
+			wantAddr:        "",
+			wantSocket:      "/tmp/test.sock",
+			wantSocketMode:  new(Mode(0777)),
+			wantSocketGroup: "",
+		},
+		{
+			name:     "SocketModeExceedsValidBits",
+			listener: Listener{Socket: "/tmp/test.sock", SocketMode: new(Mode(06660))},
+			wantErr:  true,
+		},
+		{
+			name:     "SocketModeNoReadOrWritePermission",
+			listener: Listener{Socket: "/tmp/test.sock", SocketMode: new(Mode(0100))},
+			wantErr:  true,
+		},
+		{
+			name:     "SocketGroupNotExists",
+			listener: Listener{Socket: "/tmp/test.sock", SocketMode: new(Mode(0600)), SocketGroup: "unknownGroup"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.listener.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAddr, tc.listener.Addr)
+			assert.Equal(t, tc.wantSocket, tc.listener.Socket)
+			assert.Equal(t, tc.wantSocketMode, tc.listener.SocketMode)
+			assert.Equal(t, tc.wantSocketGroup, tc.listener.SocketGroup)
+		})
+	}
+}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
+	"net"
 	"net/http"
+	"os"
+	"os/user"
+	"strconv"
 	"time"
 
 	"github.com/icinga/icinga-go-library/database"
@@ -37,21 +43,29 @@ func (rw *responseWriter) WriteHeader(status int) {
 	rw.ResponseWriter.WriteHeader(status)
 }
 
+// peerUserLookupKey is the context key under which a [peerUserLookupFunc] is stored for Unix socket connections.
+type peerUserLookupKey struct{}
+
+// peerUserLookupFunc resolves the OS username of the peer process connected via a Unix domain socket.
+type peerUserLookupFunc func() (string, error)
+
 type Listener struct {
 	db            *database.DB
 	logger        *logging.Logger
 	runtimeConfig *config.RuntimeConfig
 
-	logs *logging.Logging
-	mux  http.ServeMux
+	logs      *logging.Logging
+	mux       http.ServeMux
+	useSocket bool
 }
 
-func NewListener(db *database.DB, runtimeConfig *config.RuntimeConfig, logs *logging.Logging) *Listener {
+func NewListener(db *database.DB, runtimeConfig *config.RuntimeConfig, logs *logging.Logging, useSocket bool) *Listener {
 	l := &Listener{
 		db:            db,
 		logger:        logs.GetChildLogger("listener"),
 		logs:          logs,
 		runtimeConfig: runtimeConfig,
+		useSocket:     useSocket,
 	}
 
 	debugMux := http.NewServeMux()
@@ -88,34 +102,18 @@ func (l *Listener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		zap.String("status", http.StatusText(crw.status)))
 }
 
-// Run the Listener's web server and block until the server has finished.
+// Run starts the HTTP listener and blocks until the server finishes.
 //
-// The web server either returns (early) when its ListenAndServe fails or when the given context is finished. After the
-// context is done, the web server shuts down gracefully with a hard limit of three seconds.
-//
-// An error is returned in every case except for a gracefully context-based shutdown without hitting the time limit.
+// An error is returned in all cases except for a graceful shutdown triggered by the context being done within a
+// hardcoded time limit.
 func (l *Listener) Run(ctx context.Context) error {
-	conf := daemon.Config().Listener
-	tlsConfig, err := conf.GetTlsConfig()
-	if err != nil {
-		return err
-	}
-
-	var https string
-	if conf.TLSOptions.Enable {
-		https = "s"
-	}
-	l.logger.Infof("Starting listener on http%s://%s", https, conf.Addr)
-
 	stdlogger, err := zap.NewStdLogAt(l.logger.Desugar(), zap.ErrorLevel)
 	if err != nil {
 		return err
 	}
 
 	server := &http.Server{
-		Addr:        conf.Addr,
 		Handler:     l,
-		TLSConfig:   tlsConfig,
 		ReadTimeout: 10 * time.Second,
 		IdleTimeout: 30 * time.Second,
 		// Redirect the standard library's HTTP server error log to our logger with error level because these
@@ -123,16 +121,19 @@ func (l *Listener) Run(ctx context.Context) error {
 		ErrorLog: stdlogger,
 	}
 
+	var listeningFunc func() error
+	if l.useSocket {
+		listeningFunc, err = l.initSocketServer(server)
+	} else {
+		listeningFunc, err = l.initTcpServer(server)
+	}
+	if err != nil {
+		return err
+	}
+
 	serverErr := make(chan error, 1)
 	go func() {
-		if conf.TLSOptions.Enable {
-			// We've already created the TLS config for the server, so we can pass empty strings
-			// for certFile and keyFile, which makes ListenAndServeTLS use the TLS config directly
-			// instead of trying to load certs from files.
-			serverErr <- server.ListenAndServeTLS("", "")
-		} else {
-			serverErr <- server.ListenAndServe()
-		}
+		serverErr <- listeningFunc()
 	}()
 
 	select {
@@ -146,20 +147,172 @@ func (l *Listener) Run(ctx context.Context) error {
 	}
 }
 
-// sourceFromAuthOrAbort extracts a *config.Source from the HTTP Basic Auth. If the credentials are wrong, (nil, false) is
-// returned and 401 was written back to the response writer.
-func (l *Listener) sourceFromAuthOrAbort(w http.ResponseWriter, r *http.Request) (*config.Source, bool) {
-	if authUser, authPass, authOk := r.BasicAuth(); authOk {
-		src := l.runtimeConfig.GetSourceFromCredentials(authUser, authPass, l.logger)
-		if src != nil {
-			return src, true
+// initTcpServer configures the given HTTP(S) server for the configured TCP address and returns a function that
+// starts serving. The caller is responsible for actually calling that function and for graceful shutdown.
+func (l *Listener) initTcpServer(server *http.Server) (func() error, error) {
+	conf := daemon.Config().Listener
+	tlsConfig, err := conf.GetTlsConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	var https string
+	if conf.TLSOptions.Enable {
+		https = "s"
+	}
+	l.logger.Infof("Starting listener on http%s://%s", https, conf.Addr)
+
+	server.Addr = conf.Addr
+	server.TLSConfig = tlsConfig
+
+	if conf.TLSOptions.Enable {
+		// We've already created the TLS config for the server, so we can pass empty strings
+		// for certFile and keyFile, which makes ListenAndServeTLS use the TLS config directly
+		// instead of trying to load certs from files.
+		return func() error { return server.ListenAndServeTLS("", "") }, nil
+	}
+
+	return func() error { return server.ListenAndServe() }, nil
+}
+
+// initSocketServer configures the given HTTP server to listen on the configured Unix socket path and returns a
+// function that starts serving. If a socket file already exists at the path, it is removed before binding.
+// The caller is responsible for actually calling that function and for graceful shutdown.
+func (l *Listener) initSocketServer(server *http.Server) (fn func() error, retErr error) {
+	conf := daemon.Config().Listener
+	mode := *conf.SocketMode
+	if mode&0o006 > 0 {
+		l.logger.Warnw("Unix socket is world-accessible; consider restricting socket_mode and using socket_group instead",
+			zap.String("socket_mode", fmt.Sprintf("%04o", mode)),
+		)
+	}
+
+	path := conf.Socket
+	info, err := os.Stat(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("cannot read socket path: %w", err)
+	} else if err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("the configured socket path already exists and is not a socket: %q", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("cannot remove existing unix socket: %w", err)
 		}
 	}
 
-	w.Header().Set("WWW-Authenticate", `Basic realm="icinga-notifications source"`)
-	w.WriteHeader(http.StatusUnauthorized)
-	_, _ = fmt.Fprintln(w, "expected valid icinga-notifications source basic auth credentials")
-	return nil, false
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot listen on unix socket %q: %w", path, err)
+	}
+
+	defer func() {
+		if retErr != nil {
+			_ = listener.Close()
+		}
+	}()
+
+	if groupName := conf.SocketGroup; groupName != "" {
+		group, err := user.LookupGroup(groupName)
+		if err != nil {
+			return nil, fmt.Errorf("cannot find group %q: %w", groupName, err)
+		}
+
+		gid, err := strconv.Atoi(group.Gid)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse GID for group %q: %w", groupName, err)
+		}
+
+		if gid != -1 {
+			if err := os.Chown(path, -1, gid); err != nil {
+				return nil, fmt.Errorf("cannot change ownership of unix socket %q: %w", path, err)
+			}
+		}
+	}
+
+	if err := os.Chmod(path, fs.FileMode(mode)); err != nil {
+		return nil, fmt.Errorf("cannot set permissions on unix socket %q: %w", path, err)
+	}
+
+	server.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
+		unixConn, ok := c.(*net.UnixConn)
+		if !ok {
+			l.logger.Fatalw("expected *net.UnixConn", zap.String("connection_type", fmt.Sprintf("%T", c)))
+		}
+
+		rawConn, err := unixConn.SyscallConn()
+		if err != nil {
+			l.logger.Fatalw("Cannot extract RawConnection", zap.Error(err))
+		}
+
+		lookUpUser := func() (string, error) {
+			uid, err := socketPeerUid(rawConn)
+			if err != nil {
+				return "", fmt.Errorf("cannot obtain peer credentials: %w", err)
+			}
+
+			u, err := user.LookupId(strconv.FormatUint(uint64(uid), 10))
+			if err != nil {
+				return "", fmt.Errorf("cannot obtain user id: %w", err)
+			}
+
+			return u.Username, nil
+		}
+
+		return context.WithValue(ctx, peerUserLookupKey{}, peerUserLookupFunc(lookUpUser))
+	}
+
+	l.logger.Infof("Starting listener on unix socket %s", path)
+
+	return func() error { return server.Serve(listener) }, nil
+}
+
+// sourceFromAuthOrAbort extracts a *config.Source from the request. For Unix socket connections, the source is looked
+// up by the OS username of the connecting process via peer credentials. For TCP connections, HTTP Basic Auth is used.
+// If no matching source is found, nil is returned and 401 is written to the response.
+func (l *Listener) sourceFromAuthOrAbort(w http.ResponseWriter, r *http.Request) (src *config.Source) {
+	errFunc := func(errMsg string) *config.Source {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprintln(w, errMsg)
+		return nil
+	}
+
+	if l.useSocket {
+		l.logger.Debugw("Source is authenticated via socket connection")
+		value := r.Context().Value(peerUserLookupKey{})
+		if value == nil {
+			return errFunc("no value found in context")
+		}
+
+		lookup, ok := value.(peerUserLookupFunc)
+		if !ok {
+			return errFunc("no lookup function present")
+		}
+
+		username, err := lookup()
+		if err != nil {
+			return errFunc(err.Error())
+		}
+
+		src = l.runtimeConfig.GetSourceByUsername(username)
+		if src == nil {
+			return errFunc(fmt.Sprintf("system user %q is not registered as a source username", username))
+		}
+	} else {
+		l.logger.Debugw("Source is authenticated via HTTP Basic Auth")
+		authUser, authPass, authOk := r.BasicAuth()
+		if !authOk {
+			w.Header().Set("WWW-Authenticate", `Basic realm="icinga-notifications source"`)
+			return errFunc("missing or malformed basic auth credentials")
+		}
+
+		src = l.runtimeConfig.GetSourceFromCredentials(authUser, authPass, l.logger)
+		if src == nil {
+			w.Header().Set("WWW-Authenticate", `Basic realm="icinga-notifications source"`)
+			return errFunc("expected valid icinga-notifications source basic auth credentials")
+		}
+	}
+
+	return src
 }
 
 // abort the current connection by sending the status code and an error both to the log and back to the client.
@@ -185,8 +338,8 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	src, isAuthenticated := l.sourceFromAuthOrAbort(w, r)
-	if !isAuthenticated {
+	src := l.sourceFromAuthOrAbort(w, r)
+	if src == nil {
 		// Listener.sourceFromAuthOrAbort writes 401 response by itself; no abort() necessary.
 		return
 	}
@@ -263,8 +416,8 @@ func (l *Listener) GetIncidents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	src, isAuthenticated := l.sourceFromAuthOrAbort(w, r)
-	if !isAuthenticated {
+	src := l.sourceFromAuthOrAbort(w, r)
+	if src == nil {
 		// Listener.sourceFromAuthOrAbort writes 401 response by itself; no abort() necessary.
 		return
 	}

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -1,0 +1,181 @@
+package listener
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/user"
+	"testing"
+	"time"
+
+	"github.com/icinga/icinga-go-library/logging"
+	"github.com/icinga/icinga-go-library/types"
+	"github.com/icinga/icinga-notifications/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func makeTestListener(t *testing.T, useSocket bool) *Listener {
+	var src *config.Source
+	if useSocket {
+		u, err := user.Current()
+		require.NoError(t, err)
+
+		src = &config.Source{
+			ListenerUsername: types.MakeString(u.Username),
+		}
+	} else {
+		hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+		require.NoError(t, err)
+
+		src = &config.Source{
+			ListenerUsername:     types.MakeString("icingadb"),
+			ListenerPasswordHash: types.MakeString(string(hash)),
+		}
+	}
+
+	rc := &config.RuntimeConfig{}
+	rc.Sources = map[int64]*config.Source{1: src}
+
+	return &Listener{
+		runtimeConfig: rc,
+		useSocket:     useSocket,
+		logger:        logging.NewLogger(zaptest.NewLogger(t).Sugar(), time.Hour),
+	}
+}
+
+// withPeerUsername returns a copy of req with the given username injected into its context.
+func withPeerUsername(req *http.Request, username string) *http.Request {
+	setUser := func() (string, error) {
+		return username, nil
+	}
+	return req.WithContext(context.WithValue(req.Context(), peerUserLookupKey{}, peerUserLookupFunc(setUser)))
+}
+
+func TestSourceFromAuthOrAbort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("ValidCredsMatchingSource", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, true)
+			src := l.runtimeConfig.Sources[1]
+			username := src.ListenerUsername.String
+			req := withPeerUsername(httptest.NewRequest(http.MethodPost, "/", nil), username)
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.NotNil(t, gotSrc)
+			assert.Same(t, src, gotSrc)
+		})
+
+		t.Run("ValidCredsNoMatchingSource", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, true)
+			username := l.runtimeConfig.Sources[1].ListenerUsername.String
+			// Replace the source with one that has a different username.
+			l.runtimeConfig.Sources[1] = &config.Source{
+				ListenerUsername: types.MakeString("some-other-source"),
+			}
+			req := withPeerUsername(httptest.NewRequest(http.MethodPost, "/", nil), username)
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.Empty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+
+		t.Run("CredsWithUnknownUsername", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, true)
+			req := withPeerUsername(httptest.NewRequest(http.MethodPost, "/", nil), "unknown User")
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.Empty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+
+		t.Run("NoCredsInContext", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, true)
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.Empty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+	})
+
+	t.Run("Tcp", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("CorrectCredentials", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, false)
+			src := l.runtimeConfig.Sources[1]
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.SetBasicAuth("icingadb", "secret")
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.NotNil(t, gotSrc)
+			assert.Same(t, src, gotSrc)
+		})
+
+		t.Run("WrongPassword", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, false)
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.SetBasicAuth("icingadb", "wrongpassword")
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.NotEmpty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+
+		t.Run("UnknownUsername", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, false)
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.SetBasicAuth("unknown", "secret")
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.NotEmpty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+
+		t.Run("MissingAuthHeader", func(t *testing.T) {
+			t.Parallel()
+
+			l := makeTestListener(t, false)
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			rw := httptest.NewRecorder()
+
+			gotSrc := l.sourceFromAuthOrAbort(rw, req)
+			assert.Nil(t, gotSrc)
+			assert.Equal(t, http.StatusUnauthorized, rw.Code)
+			assert.NotEmpty(t, rw.Header().Get("WWW-Authenticate"))
+		})
+	})
+}

--- a/internal/listener/socket_uid_darwin.go
+++ b/internal/listener/socket_uid_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package listener
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func socketPeerUid(rawConn syscall.RawConn) (uint32, error) {
+	var xucreds *unix.Xucred
+	var xucredsErr error
+	err := rawConn.Control(func(fd uintptr) {
+		xucreds, xucredsErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if xucredsErr != nil {
+		return 0, xucredsErr
+	}
+
+	return xucreds.Uid, nil
+}

--- a/internal/listener/socket_uid_linux.go
+++ b/internal/listener/socket_uid_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package listener
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func socketPeerUid(rawConn syscall.RawConn) (uint32, error) {
+	var creds *unix.Ucred
+	var credsErr error
+	err := rawConn.Control(func(fd uintptr) {
+		creds, credsErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if credsErr != nil {
+		return 0, credsErr
+	}
+
+	return creds.Uid, nil
+}


### PR DESCRIPTION
## Support HTTP over Unix sockets

Sources running on the same host as Icinga Notifications can now connect via a Unix domain socket instead of (or alongside) TCP. This removes the need to expose a network port for local sources and avoids password verification overhead, as the socket transport itself provides the trust boundary.

### Changes

**Configuration** (`internal/daemon/config.go`)

Three new fields are added to the `Listener` config block:

```yaml
listener:
  socket: /run/icinga-notifications/notifications.sock
  socket_mode: "0660"  # optional, defaults to 0600
  socket_group: icinga  # optional
```

`Validate()` is updated so the TCP address only defaults to `localhost:5680` when no socket is configured; setting `socket` without `address` starts the socket listener exclusively. It also removes a stale socket file at the configured path if one already exists.

**Listener** (`internal/listener/listener.go`)

`NewListener` gains a `useSocket bool` parameter. `Run()` dispatches to either `runTCP()` (the existing logic, renamed) or the new `runSocket()`, which:

- Listens on the configured Unix path via `net.Listen("unix", ...)`
- Sets group ownership via `os.Chown` when `socket_group` is configured
- Sets permissions via `os.Chmod` immediately after binding
- Shuts down gracefully on context cancellation, same as the TCP path

Authentication on the socket path uses OS peer credentials (`SO_PEERCRED`): the daemon reads the connecting process's UID from the kernel, resolves it to an OS username via `user.LookupId`, and matches it against the source's configured username; no password or HTTP Basic Auth is involved. The TCP path continues to use full credential verification. The `WWW-Authenticate` response header is omitted on the socket path since browser-style auth prompts are not applicable there.

**Runtime config** (`internal/config/runtime.go`)

`GetSourceFromUsername` is added alongside the existing `GetSourceFromCredentials`. It matches sources by `listener_username` without checking the password hash, and explicitly guards against matching sources that have no username configured (`ListenerUsername.Valid == false`).

**Main** (`cmd/icinga-notifications/main.go`)

Both listeners are started concurrently via `errgroup`. If only one is configured, only that one runs. Either listener failing propagates the error and cancels the other through the shared context.

### Tests

- `TestListenerValidate`: covers the `Validate()` address-defaulting logic: nothing configured, socket-only, explicit address, both, and invalid/empty `socket_mode` strings
- `TestGetSourceFromUsername`: known usernames, unknown username, and sources with no configured username not matched by empty string
- `TestSourceFromAuthOrAbort` : socket path: valid peer credentials matching a source username succeed, unknown UID and missing credentials both return 401 without `WWW-Authenticate`; TCP path: correct credentials pass, wrong password and unknown username both return 401 with `WWW-Authenticate`


resolves #412 
