### PR TITLE
Implement HA for Distributed Setups

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -14,13 +15,25 @@ import (
 	"github.com/icinga/icinga-notifications/internal/channel"
 	"github.com/icinga/icinga-notifications/internal/config"
 	"github.com/icinga/icinga-notifications/internal/daemon"
+	"github.com/icinga/icinga-notifications/internal/event"
 	"github.com/icinga/icinga-notifications/internal/incident"
 	"github.com/icinga/icinga-notifications/internal/listener"
 	"github.com/icinga/icinga-notifications/internal/retention"
 	"github.com/okzk/sdnotify"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	ExitSuccess = 0
+	ExitFailure = 1
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	daemon.ParseFlagsAndConfig()
 	conf := daemon.Config()
 
@@ -65,19 +78,69 @@ func main() {
 		logger.Fatalf("Cannot load incidents from database: %+v", err)
 	}
 
-	ret := retention.New(db, logs.GetChildLogger("retention"))
-	go func() {
-		if err := ret.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Fatalf("Retention has finished with an error: %+v", err)
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		err := retention.New(db, logs.GetChildLogger("retention")).Run(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			logger.Info("Retention has finished")
+			return nil
+		} else {
+			logger.Errorf("Retention has finished with an error: %+v", err)
+			return err
 		}
-	}()
+	})
+
+	eg.Go(func() error {
+		err := listener.NewListener(db, runtimeConfig, logs).Run(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			logger.Info("Listener has finished")
+			return nil
+		} else {
+			logger.Errorf("Listener has finished with an error: %+v", err)
+			return err
+		}
+	})
+
+	eg.Go(func() error {
+		logger := logs.GetChildLogger("event-queue")
+		err := event.ProcessQueue(
+			ctx,
+			db,
+			logger,
+			func(ctx context.Context, ev *event.Event) error {
+				err := incident.ProcessEvent(ctx, db, logs, runtimeConfig, ev)
+				if errors.Is(err, incident.ErrSeverityChangeWithoutIncidentFlag) ||
+					errors.Is(err, incident.ErrOpenIncidentWithoutSeverity) {
+					logger.Debugw("Skipping event processing",
+						zap.String("event_name", ev.Name),
+						zap.Error(err))
+					return nil
+				} else if err != nil {
+					logger.Errorw("Failed to successfully process event",
+						zap.String("event_name", ev.Name),
+						zap.Error(err))
+					return err
+				}
+
+				logger.Infow("Successfully processed event", zap.String("event_name", ev.Name))
+				return nil
+			})
+		if err == nil || errors.Is(err, context.Canceled) {
+			logger.Info("Event queue processor has finished")
+			return nil
+		} else {
+			logger.Errorf("Event queue processor has finished with an error: %+v", err)
+			return err
+		}
+	})
 
 	// When Icinga Notifications is started by systemd, we've to notify systemd that we're ready.
 	_ = sdnotify.Ready()
 
-	if err := listener.NewListener(db, runtimeConfig, logs).Run(ctx); err != nil {
-		logger.Errorf("Listener has finished with an error: %+v", err)
-	} else {
-		logger.Info("Listener has finished")
+	if err := eg.Wait(); err != nil {
+		return ExitFailure
 	}
+
+	return ExitSuccess
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -112,6 +112,7 @@ retention:
     #channel:
     #database:
     #incident:
+    #event-queue:
     #listener:
     #retention:
     #runtime-updates:

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -201,6 +201,7 @@ ICINGA_NOTIFICATIONS_LOGGING_OPTIONS=database:error,listener:debug
 | channel         | Notification channels, their configuration and output.                    |
 | database        | Database connection status and queries.                                   |
 | incident        | Incident management and changes.                                          |
+| event-queue     | Event queue handles events enqueued in the database.                      |
 | listener        | HTTP listener for event submission and debugging.                         |
 | retention       | Data retention and cleanup.                                               |
 | runtime-updates | Configuration changes through Icinga Notifications Web from the database. |

--- a/doc/05-Distributed-Setups.md
+++ b/doc/05-Distributed-Setups.md
@@ -1,3 +1,38 @@
 # Distributed Setups
 
-To be done.
+Icinga Notifications supports running multiple daemon instances against a single shared database.
+This allows for high-availability setups where instances share the processing load
+and the remaining instances continue operating if one becomes unavailable.
+
+## Architecture
+
+All instances share the same database for both configuration and event processing.
+When an event is received via the [HTTP API](20-HTTP-API.md),
+the receiving instance writes it to a queue table in the database rather than processing it immediately.
+A background worker in each instance continuously polls this queue and claims events for processing.
+
+The database ensures that each event is processed exactly once across all running instances.
+There is no leader election; all instances are equal and contribute to the shared workload.
+
+Although database queries ensure that no two instances operate on identical objects, submission time is important.
+Therefore, ensure that all nodes have identical system times, e.g., via NTP.
+
+## Configuration
+
+To run additional instances, install Icinga Notifications on another host and point it at the same database.
+No additional configuration is required beyond what is described in [Configuration](03-Configuration.md).
+
+Each instance must be able to reach the database and requires any configured notification channels to be installed.
+The HTTP API of each instance operates independently.
+If you place a load balancer in front of multiple instances,
+incoming events will be distributed across them and processed from the shared queue.
+
+## Corrupt Queue Entries
+
+The event queue is designed to be an internal API, where no external process is allowed to insert events.
+Thus, it is expected to only contain valid data.
+
+Nevertheless, in the unlikely case that corrupted data crept into the `event_queue` table,
+Icinga Notifications will log an error and mark the event as failed in the database.
+The log contains a reference to the invalid `event_queue` row including its `id`.
+This allows inspecting the entry in the relational database and eventually fixing or deleting it.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -23,7 +23,7 @@ import (
 // into its JSON representation.
 type Event struct {
 	Time     time.Time `json:"-"`
-	SourceId int64     `json:"-"`
+	SourceId int64     `json:"source_id"`
 
 	baseEv.Event `json:",inline"`
 

--- a/internal/event/queue.go
+++ b/internal/event/queue.go
@@ -1,0 +1,227 @@
+package event
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/icinga/icinga-go-library/backoff"
+	"github.com/icinga/icinga-go-library/database"
+	"github.com/icinga/icinga-go-library/logging"
+	"github.com/icinga/icinga-go-library/retry"
+	"github.com/icinga/icinga-go-library/types"
+	"github.com/icinga/icinga-notifications/internal"
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+)
+
+const (
+	// The following consts are valid values for Queue.State.
+	//
+	// - queueStatePending is the initial state for submitting events.
+	// - queueStateProcessing is assigned when the ListenQueue picked this up for processing.
+	// - queueStateDone is set after ListenQueue successfully processed the entry.
+	// - queueStateError is assigned to invalid events for further processing.
+	//
+	// queueStateDone ensures that a source cannot enqueue the same event after it was already processed. If the event
+	// would have been already deleted from the database, but the source resubmits it due to some source-facing network
+	// issues, it would have been evaluated once again. By keeping evaluated events with the queueStateDone state in
+	// the database for a few minutes eliminates this potential issue.
+	queueStatePending    int16 = 0
+	queueStateProcessing int16 = 1
+	queueStateDone       int16 = 2
+	queueStateError      int16 = 64
+)
+
+// Queue describes an event.Event enqueued for processing in the relational database.
+type Queue struct {
+	// ID is the SHA256 hash based on the event.Event JSON representation.
+	ID types.Binary `db:"id"`
+
+	// Json serialization and Time from the event.Event. Time is required for database ordering.
+	Json string          `db:"json"`
+	Time types.UnixMilli `db:"time"`
+
+	// ObjectId is the Object ID of the event, used to exclude related queue entries on the database level.
+	ObjectId types.Binary `db:"object_id"`
+
+	// UserAgent describes the submitting client; allows migrations after upgrades.
+	UserAgent string `db:"user_agent"`
+
+	// State of the event. Check "queueState*" consts above.
+	State int16 `db:"state"`
+}
+
+// TableName implements [database.TableNamer].
+func (q *Queue) TableName() string {
+	return "event_queue"
+}
+
+// toEvent recreates an event.Event based on the JSON representation and the other fields stored in the database.
+func (q *Queue) toEvent() (*Event, error) {
+	var ev Event
+
+	// NOTE: There might be breaking changes with future updates. If this happens, this function should honor the
+	// UserAgent field and apply necessary migration steps.
+
+	err := json.NewDecoder(strings.NewReader(q.Json)).Decode(&ev)
+	if err != nil {
+		return nil, fmt.Errorf("cannot JSON decode event queue entry: %w", err)
+	}
+
+	ev.Time = q.Time.Time()
+
+	return &ev, nil
+}
+
+// Enqueue enqueues an event.Event into the event queue.
+//
+// The internally used database transaction is bound to the provided context. When calling this function from an HTTP
+// handler, pass the request's context to terminate the transaction if the client disconnects prematurely.
+func Enqueue(ctx context.Context, db *database.DB, ev *Event, objectID types.Binary) error {
+	jsonBuff := bytes.Buffer{}
+	idHash := sha256.New()
+
+	err := json.NewEncoder(io.MultiWriter(&jsonBuff, idHash)).Encode(ev)
+	if err != nil {
+		return fmt.Errorf("cannot JSON encode event.Event: %w", err)
+	}
+
+	q := &Queue{
+		ID:        idHash.Sum(nil),
+		Json:      jsonBuff.String(),
+		Time:      types.UnixMilli(ev.Time),
+		ObjectId:  objectID,
+		UserAgent: "icinga-notifications/" + internal.Version.Version,
+		State:     queueStatePending,
+	}
+	stmt, _ := db.BuildInsertIgnoreStmt(q)
+
+	return retry.WithBackoff(
+		ctx,
+		func(ctx context.Context) error {
+			return db.ExecTx(
+				ctx,
+				&sql.TxOptions{Isolation: sql.LevelSerializable},
+				func(ctx context.Context, tx *sqlx.Tx) error {
+					_, err := tx.NamedExecContext(ctx, stmt, q)
+					if err != nil {
+						return database.CantPerformQuery(err, stmt)
+					}
+
+					return nil
+				})
+		},
+		retry.Retryable,
+		backoff.DefaultBackoff,
+		db.GetDefaultRetrySettings())
+}
+
+// ProcessQueue fetches events from the database event queue and forwards them to the callback.
+//
+// This function blocks until either an error occurred or the passed context is finished. In either case, an error is
+// being returned.
+func ProcessQueue(
+	ctx context.Context,
+	db *database.DB,
+	logger *logging.Logger,
+	callback func(context.Context, *Event) error,
+) error {
+	selStmt := db.Rebind(`
+		SELECT q1.*
+		FROM event_queue q1
+		LEFT JOIN event_queue q2 ON
+			q2.state = ` + fmt.Sprintf("%d", queueStateProcessing) + ` AND
+			q1.object_id = q2.object_id
+		WHERE
+			q1.state = ` + fmt.Sprintf("%d", queueStatePending) + ` AND
+			q2.object_id IS NULL
+		ORDER BY q1.time
+		LIMIT 1`)
+	updStmt := `UPDATE event_queue SET state = :state WHERE id = :id`
+
+	for ctx.Err() == nil {
+		var q Queue
+
+		err := retry.WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				return db.ExecTx(
+					ctx,
+					&sql.TxOptions{Isolation: sql.LevelSerializable},
+					func(ctx context.Context, tx *sqlx.Tx) error {
+						err := tx.GetContext(ctx, &q, selStmt)
+						if err != nil {
+							return database.CantPerformQuery(err, selStmt)
+						}
+
+						q.State = queueStateProcessing
+						_, err = tx.NamedExecContext(ctx, updStmt, q)
+						if err != nil {
+							return database.CantPerformQuery(err, updStmt)
+						}
+
+						return nil
+					})
+			},
+			func(err error) bool {
+				if errors.Is(err, sql.ErrNoRows) {
+					return true
+				}
+				return retry.Retryable(err)
+			},
+			backoff.NewExponentialWithJitter(time.Second, 3*time.Second),
+			retry.Settings{Timeout: retry.DefaultTimeout})
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("cannot fetch event from event queue: %w", err)
+		}
+
+		logger.Debugw("Claimed event queue entry for processing",
+			zap.Stringer("id", q.ID),
+			zap.Stringer("object_id", q.ObjectId))
+
+		if ev, err := q.toEvent(); err != nil {
+			logger.Errorw("Invalid event queue event cannot get decoded", zap.Stringer("id", q.ID), zap.Error(err))
+			q.State = queueStateError
+		} else if err = callback(ctx, ev); err != nil {
+			logger.Errorw("Event queue event cannot be processed", zap.Stringer("id", q.ID), zap.Error(err))
+			q.State = queueStateError
+		} else {
+			logger.Debugw("Processed event from event queue", zap.Stringer("id", q.ID))
+			q.State = queueStateDone
+		}
+
+		err = retry.WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				return db.ExecTx(
+					ctx,
+					&sql.TxOptions{Isolation: sql.LevelSerializable},
+					func(ctx context.Context, tx *sqlx.Tx) error {
+						_, err = tx.NamedExecContext(ctx, updStmt, q)
+						if err != nil {
+							return database.CantPerformQuery(err, updStmt)
+						}
+
+						return nil
+					})
+			},
+			retry.Retryable,
+			backoff.DefaultBackoff,
+			db.GetDefaultRetrySettings())
+		if err != nil {
+			return fmt.Errorf("cannot update queue entry %q after processing: %w", q.ID, err)
+		}
+	}
+
+	return ctx.Err()
+}

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -151,18 +151,20 @@ func (i *Incident) ProcessEvent(ctx context.Context, ev *event.Event) error {
 
 		i.logger = i.logger.With(zap.String("incident", i.String()))
 	} else {
+		if err := i.restoreState(ctx, tx); err != nil {
+			return err
+		}
+
+		if !i.RecoveredAt.Time().IsZero() {
+			RemoveCurrent(i.Object)
+			return ErrIncidentRecovered
+		}
+
 		if sevChanged, err := i.processSeverityChangedEvent(ctx, tx, ev); err != nil {
 			return err
 		} else {
 			// In case the severity didn't change, we need to check whether we can trigger notifications nonetheless.
 			triggerNotifications = sevChanged || ev.NotifyRecipients() || (ev.Muted.Valid && ev.IsMuted() != i.IsMuted())
-		}
-
-		// For all existing incidents, we have to reload the recipients from the database to ensure that we have the
-		// most up-to-date recipient list, since the recipients or recipients roles might have changed since users
-		// are allowed to subscribe or manage incidents from within Icinga Notifications Web.
-		if err := i.restoreRecipients(ctx); err != nil {
-			return err
 		}
 	}
 
@@ -241,6 +243,19 @@ func (i *Incident) RetriggerEscalations(ev *event.Event) {
 	i.runtimeConfig.RLock()
 	defer i.runtimeConfig.RUnlock()
 
+	ctx := context.Background()
+	tx, err := i.db.BeginTxx(ctx, nil)
+	if err != nil {
+		i.logger.Errorw("Cannot start a db transaction for escalation reevaluation", zap.Error(err))
+		return
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := i.restoreState(ctx, tx); err != nil {
+		i.logger.Errorw("Cannot restore incident state for escalation reevaluation", zap.Error(err))
+		return
+	}
+
 	if !i.RecoveredAt.Time().IsZero() {
 		// Incident is recovered in the meantime.
 		return
@@ -262,31 +277,33 @@ func (i *Incident) RetriggerEscalations(ev *event.Event) {
 		return
 	}
 
-	var notifications []*NotificationEntry
-	ctx := context.Background()
-	err = i.db.ExecTx(ctx, nil, func(ctx context.Context, tx *sqlx.Tx) error {
-		if err = i.triggerEscalations(ctx, tx, escalations); err != nil {
-			return err
-		}
+	if err := i.triggerEscalations(ctx, tx, escalations); err != nil {
+		i.logger.Errorw("Reevaluating time-based escalations failed", zap.Error(err))
+		return
+	}
 
-		channels := make(rule.ContactChannels)
-		for _, escalation := range escalations {
-			channels.LoadFromEscalationRecipients(escalation, ev.Time, i.isRecipientNotifiable)
-		}
+	channels := make(rule.ContactChannels)
+	for _, escalation := range escalations {
+		channels.LoadFromEscalationRecipients(escalation, ev.Time, i.isRecipientNotifiable)
+	}
 
-		notifications, err = i.generateNotifications(ctx, tx, ev, channels)
-		return err
-	})
+	notifications, err := i.generateNotifications(ctx, tx, ev, channels)
 	if err != nil {
 		i.logger.Errorw("Reevaluating time-based escalations failed", zap.Error(err))
-	} else {
-		if err = i.notifyContacts(ctx, ev, notifications); err != nil {
-			i.logger.Errorw("Failed to notify reevaluated escalation recipients", zap.Error(err))
-			return
-		}
-
-		i.logger.Info("Successfully reevaluated time-based escalations")
+		return
 	}
+
+	if err := tx.Commit(); err != nil {
+		i.logger.Errorw("Cannot commit transaction for escalation reevaluation", zap.Error(err))
+		return
+	}
+
+	if err := i.notifyContacts(ctx, ev, notifications); err != nil {
+		i.logger.Errorw("Failed to notify reevaluated escalation recipients", zap.Error(err))
+		return
+	}
+
+	i.logger.Info("Successfully reevaluated time-based escalations")
 }
 
 // Close closes the current incident if not already recovered.
@@ -324,6 +341,11 @@ func (i *Incident) Close(ctx context.Context, tx *sqlx.Tx, persist bool) error {
 // ErrSeverityChangeWithoutIncidentFlag is returned when an event tries to change the severity of an incident
 // but does not set the 'incident' flag.
 var ErrSeverityChangeWithoutIncidentFlag = errors.New("cannot change severity of an incident with an event that doesn't set the 'incident' flag")
+
+// ErrIncidentRecovered is returned when an incident was found to be already recovered by another node in HA mode.
+//
+// When Incident.Listener returns this error, the related object was removed from the current incidents.
+var ErrIncidentRecovered = errors.New("incident was recovered by another node")
 
 // processSeverityChangedEvent processes the given event as a severity changed event, if the severity has actually changed.
 //
@@ -701,12 +723,46 @@ func (i *Incident) getRecipientsChannel(t time.Time) rule.ContactChannels {
 	return contactChs
 }
 
-// restoreRecipients reloads the current incident recipients from the database.
-// Returns error on database failure.
-func (i *Incident) restoreRecipients(ctx context.Context) error {
-	contact := &ContactRow{}
+// restoreState reloads all incident state from the database within the given transaction.
+//
+// This method must be called for existing Incidents before processing an event, as another node in an HA setup may
+// have altered the state in the meantime. The incident row is locked via SELECT FOR UPDATE so that concurrent calls
+// on other nodes for the same incident are serialized until the caller commits.
+func (i *Incident) restoreState(ctx context.Context, tx *sqlx.Tx) error {
+	stmt := i.db.Rebind(i.db.BuildSelectStmt(i, i) + ` WHERE "id" = ? FOR UPDATE`)
+	if err := tx.GetContext(ctx, i, stmt, i.Id); err != nil {
+		i.logger.Errorw("Failed to restore incident row from the database", zap.Error(err))
+		return err
+	}
+
+	var states []*EscalationState
+	err := tx.SelectContext(
+		ctx,
+		&states,
+		i.db.Rebind(i.db.BuildSelectStmt(new(EscalationState), new(EscalationState))+` WHERE "incident_id" = ?`),
+		i.Id)
+	if err != nil {
+		i.logger.Errorw("Failed to restore incident escalation states from the database", zap.Error(err))
+		return err
+	}
+
+	escalationStates := make(map[escalationID]*EscalationState)
+	rules := make(map[ruleID]struct{})
+	for _, state := range states {
+		escalationStates[state.RuleEscalationID] = state
+		if escalation := i.runtimeConfig.GetRuleEscalation(state.RuleEscalationID); escalation != nil {
+			rules[escalation.RuleID] = struct{}{}
+		}
+	}
+	i.EscalationState = escalationStates
+	i.Rules = rules
+
 	var contacts []*ContactRow
-	err := i.db.SelectContext(ctx, &contacts, i.db.Rebind(i.db.BuildSelectStmt(contact, contact)+` WHERE "incident_id" = ?`), i.Id)
+	err = tx.SelectContext(
+		ctx,
+		&contacts,
+		i.db.Rebind(i.db.BuildSelectStmt(new(ContactRow), new(ContactRow))+` WHERE "incident_id" = ?`),
+		i.Id)
 	if err != nil {
 		i.logger.Errorw("Failed to restore incident recipients from the database", zap.Error(err))
 		return err
@@ -716,7 +772,6 @@ func (i *Incident) restoreRecipients(ctx context.Context) error {
 	for _, contact := range contacts {
 		recipients[contact.Key] = &RecipientState{Role: contact.Role}
 	}
-
 	i.Recipients = recipients
 
 	return nil

--- a/internal/incident/incidents.go
+++ b/internal/incident/incidents.go
@@ -2,6 +2,7 @@ package incident
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sync"
 	"time"
@@ -199,6 +200,37 @@ func GetCurrentIncidentsForSource(sourceID int64) []*Incident {
 // ErrOpenIncidentWithoutSeverity is returned when an event tries to open a new incident without a severity.
 var ErrOpenIncidentWithoutSeverity = errors.New("cannot open or escalate an incident without a severity")
 
+// loadOpenIncidentForObject checks the database for an open Incident and adds it to currentIncidents.
+//
+// In HA setups, another node may have created an Incident we don't know about after loadOpenIncidents.
+func loadOpenIncidentForObject(
+	ctx context.Context,
+	db *database.DB,
+	logger *logging.Logger,
+	runtimeConfig *config.RuntimeConfig,
+	obj *object.Object,
+) error {
+	i := NewIncident(db, obj, runtimeConfig, logger.With(zap.String("object", obj.DisplayName())))
+
+	stmt := db.Rebind(db.BuildSelectStmt(i, i) + ` WHERE "recovered_at" IS NULL AND "object_id" = ?`)
+	err := db.GetContext(ctx, i, stmt, obj.ID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "cannot load open incident for object")
+	}
+
+	i.logger = i.logger.With(zap.String("incident", i.String()))
+
+	currentIncidentsMu.Lock()
+	defer currentIncidentsMu.Unlock()
+	if currentIncidents[obj] == nil {
+		currentIncidents[obj] = i
+	}
+
+	return nil
+}
+
 // ProcessEvent from an event.Event.
 //
 // This function first gets this Event's object.Object and its incident.Incident. Then, after performing some safety
@@ -215,6 +247,14 @@ func ProcessEvent(
 	ev *event.Event,
 ) error {
 	o := object.Get(db, ev)
+
+	if !HasCurrent(o) {
+		err := loadOpenIncidentForObject(ctx, db, logs.GetChildLogger("incident"), runtimeConfig, o)
+		if err != nil {
+			return err
+		}
+	}
+
 	if ev.OpenOrEscalate() && ev.Severity == baseEv.SeverityNone && !HasCurrent(o) {
 		return ErrOpenIncidentWithoutSeverity
 	}
@@ -233,7 +273,12 @@ func ProcessEvent(
 		return nil
 	}
 
-	return currentIncident.ProcessEvent(ctx, ev)
+	if err := currentIncident.ProcessEvent(ctx, ev); errors.Is(err, ErrIncidentRecovered) {
+		// If in an HA setup another node just have closed the incident, retry after the cache entry was removed.
+		return ProcessEvent(ctx, db, logs, runtimeConfig, ev)
+	} else {
+		return err
+	}
 }
 
 // HasCurrent returns true if there is an active incident for the given object.

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/icinga/icinga-go-library/notifications"
@@ -15,9 +17,8 @@ import (
 	"github.com/icinga/icinga-notifications/internal/daemon"
 	"github.com/icinga/icinga-notifications/internal/event"
 	"github.com/icinga/icinga-notifications/internal/incident"
+	"github.com/icinga/icinga-notifications/internal/object"
 	"go.uber.org/zap"
-	"net/http"
-	"time"
 )
 
 // responseWriter is a wrapper around [http.ResponseWriter] that captures the status code written to the response.
@@ -190,22 +191,25 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var ev event.Event
-	if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+	var innerEv baseEv.Event
+	if err := json.NewDecoder(r.Body).Decode(&innerEv); err != nil {
 		l.abort(w, http.StatusBadRequest, nil, "cannot parse JSON body: %v", err)
 		return
 	}
 
+	ev := event.Event{
+		Time:     time.Now(),
+		SourceId: src.ID,
+		Event:    innerEv,
+	}
 	ev.CompleteURL(daemon.Config().IcingaWeb2UrlParsed)
-	ev.Time = time.Now()
-	ev.SourceId = src.ID
 
 	if err := ev.Validate(); err != nil {
 		l.abort(w, http.StatusBadRequest, src, "%v", err)
 		return
 	}
 
-	l.logger.Debugw("Processing event", zap.String("source", src.Name), zap.Object("event", &ev))
+	l.logger.Debugw("Received event", zap.String("source", src.Name), zap.Object("event", &ev))
 
 	// Submitting an event without the "incident" field won't cause any new event rules to be evaluated or
 	// escalations to be triggered, but only updates the state of an existing incident without a severity change.
@@ -218,20 +222,38 @@ func (l *Listener) ProcessEvent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err := incident.ProcessEvent(context.Background(), l.db, l.logs, l.runtimeConfig, &ev)
-	if errors.Is(err, incident.ErrSeverityChangeWithoutIncidentFlag) || errors.Is(err, incident.ErrOpenIncidentWithoutSeverity) {
-		l.abort(w, http.StatusBadRequest, src, "%v", err)
-		return
-	} else if err != nil {
-		l.logger.Errorw("Failed to successfully process event", zap.String("source", src.Name), zap.Error(err))
-		l.abort(w, http.StatusInternalServerError, src, "event could not be processed successfully, see server logs for details")
+	// Enqueue the event restricted to the HTTP request context, and restrict it further to well-guessed ten seconds.
+	//
+	// Doing so reduces the chance that event queueing works, while the HTTP client disappears. Unfortunately, this
+	// cannot be done in reverse - like with a callback, writing the HTTP response within the transaction -, as at this
+	// moment it is unknown if the transaction will succeed. This approach binds the transaction to the request context
+	// and has a minimum interval between COMMIT and writing back a response.
+	//
+	// Of course, the client might disappear without disconnecting. Unless we have some super aggressive TCP heartbeat,
+	// this will fall through. But, for the moment, I am totally fine with this.
+	//
+	// Nevertheless, event.Event submissions should be unique, especially due to the Event.ID field. Thus, if a client
+	// resubmits an identical event, its event.Queue.ID should be identical as well, resulting in a no-op.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	err := event.Enqueue(ctx, l.db, &ev, object.ID(ev.SourceId, ev.Tags))
+	if err != nil {
+		l.logger.Errorw("Failed to enqueue event into event queue",
+			zap.String("source", src.Name),
+			zap.String("event_name", ev.Name),
+			zap.Error(err))
+
+		l.abort(w, http.StatusInternalServerError, src, "internal error: see server logs for details")
 		return
 	}
 
-	l.logger.Infow("Successfully processed event", zap.String("source", src.Name))
+	l.logger.Debugw("Successfully enqueued event for future processing",
+		zap.String("source", src.Name),
+		zap.String("event_name", ev.Name))
 
 	w.WriteHeader(http.StatusAccepted)
-	_, _ = fmt.Fprintln(w, "event processed successfully")
+	_, _ = fmt.Fprintln(w, "event accepted for processing")
 	_, _ = fmt.Fprintln(w)
 }
 

--- a/internal/retention/prune.go
+++ b/internal/retention/prune.go
@@ -3,6 +3,7 @@ package retention
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/com"
@@ -23,7 +24,11 @@ type TimeBoundPruner struct {
 	PK         string
 	TimeColumn string
 
-	Referrers []ReferencingRowPruner
+	Referrers      []ReferencingRowPruner
+	ExtraCondition string
+
+	// OverridePeriodAndInterval, when non-zero, overrides the global retention period and interval to this value.
+	OverridePeriodAndInterval time.Duration
 }
 
 // Exec prunes rows from the specified table that are older than the given time threshold.
@@ -78,9 +83,20 @@ func (tbp *TimeBoundPruner) Exec(ctx context.Context, db *database.DB, olderThan
 	}
 }
 
+// whereClause returns the additional WHERE with an AND from WhereCondition, if set, or an empty string otherwise.
+func (tbp *TimeBoundPruner) whereClause() string {
+	if tbp.ExtraCondition != "" {
+		return "AND " + tbp.ExtraCondition
+	}
+
+	return ""
+}
+
 // assembleSelect constructs a select stmt to retrieve primary keys of this pruner based on the time column and limit.
 func (tbp *TimeBoundPruner) assembleSelect(limit uint64) string {
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE %[3]s IS NOT NULL AND %[3]s < ? LIMIT %d`, tbp.PK, tbp.Table, tbp.TimeColumn, limit)
+	return fmt.Sprintf(
+		`SELECT %[1]s FROM %[2]s WHERE %[3]s IS NOT NULL AND %[3]s < ? %[4]s LIMIT %[5]d`,
+		tbp.PK, tbp.Table, tbp.TimeColumn, tbp.whereClause(), limit)
 }
 
 // assembleDelete constructs a delete stmt for this pruner based on the database driver and whether we are
@@ -93,12 +109,14 @@ func (tbp *TimeBoundPruner) assembleDelete(driverName string, limit uint64, byPK
 
 	switch driverName {
 	case database.MySQL:
-		return fmt.Sprintf(`DELETE FROM %s WHERE %[2]s IS NOT NULL AND %[2]s < ? LIMIT %d`, tbp.Table, tbp.TimeColumn, limit)
+		return fmt.Sprintf(
+			`DELETE FROM %[1]s WHERE %[2]s IS NOT NULL AND %[2]s < ? %[3]s LIMIT %[4]d`,
+			tbp.Table, tbp.TimeColumn, tbp.whereClause(), limit)
 	case database.PostgreSQL:
 		return fmt.Sprintf(`
-WITH rows AS (SELECT %[1]s FROM %[2]s WHERE %[3]s IS NOT NULL AND %[3]s < ? LIMIT %[4]d)
-DELETE FROM %[2]s WHERE %[1]s IN (SELECT * FROM rows)`,
-			tbp.PK, tbp.Table, tbp.TimeColumn, limit)
+			WITH rows AS (SELECT %[1]s FROM %[2]s WHERE %[3]s IS NOT NULL AND %[3]s < ? %[4]s LIMIT %[5]d)
+			DELETE FROM %[2]s WHERE %[1]s IN (SELECT * FROM rows)`,
+			tbp.PK, tbp.Table, tbp.TimeColumn, tbp.whereClause(), limit)
 	default:
 		panic(fmt.Sprintf("invalid database type %s", driverName))
 	}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -2,6 +2,7 @@ package retention
 
 import (
 	"context"
+	"time"
 
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
@@ -36,8 +37,15 @@ func (r *Retention) Run(ctx context.Context) error {
 	var errs chan error
 	for _, pruner := range dbPruners {
 		period := conf.Period
+		interval := conf.Interval
+
 		if pruner.Table == "incident" && conf.Options.Incident != nil {
 			period = *conf.Options.Incident
+		}
+
+		if pruner.OverridePeriodAndInterval != 0 {
+			period = pruner.OverridePeriodAndInterval
+			interval = pruner.OverridePeriodAndInterval
 		}
 
 		if period == 0 {
@@ -51,10 +59,10 @@ func (r *Retention) Run(ctx context.Context) error {
 
 		r.logger.Debugw("Starting retention",
 			zap.String("table", pruner.Table),
-			zap.Duration("interval", conf.Interval),
+			zap.Duration("interval", interval),
 			zap.Duration("period", period))
 
-		periodic.Start(ctx, conf.Interval, func(tick periodic.Tick) {
+		periodic.Start(ctx, interval, func(tick periodic.Tick) {
 			olderThan := tick.Time.Add(-period)
 
 			r.logger.Debugf("Pruning data from table %s older than %s", pruner.Table, olderThan)
@@ -102,5 +110,30 @@ var dbPruners = []TimeBoundPruner{
 			{Table: "incident_history", FK: "incident_id"},
 			{Table: "incident_rule_escalation_state", FK: "incident_id"},
 		},
+	},
+	// Extra pruners for the event_queue.
+	{
+		// Events being processed too long - implies crashed daemon.
+		Table:                     "event_queue",
+		PK:                        "id",
+		TimeColumn:                "time",
+		ExtraCondition:            "state = 1",
+		OverridePeriodAndInterval: 15 * time.Minute,
+	},
+	{
+		// Successfully processed events.
+		Table:                     "event_queue",
+		PK:                        "id",
+		TimeColumn:                "time",
+		ExtraCondition:            "state = 2",
+		OverridePeriodAndInterval: 5 * time.Minute,
+	},
+	{
+		// Events in the error state.
+		Table:                     "event_queue",
+		PK:                        "id",
+		TimeColumn:                "time",
+		ExtraCondition:            "state = 64",
+		OverridePeriodAndInterval: 24 * time.Hour,
 	},
 }

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -436,6 +436,23 @@ CREATE TABLE incident_history (
 
 CREATE INDEX idx_incident_history_time_type ON incident_history(time, type) COMMENT 'Incident History ordered by time/type';
 
+CREATE TABLE event_queue (
+    id binary(32) NOT NULL, -- SHA256 of JSON representation.
+
+    json longtext NOT NULL,
+    time bigint NOT NULL,
+    object_id binary(32) NOT NULL, -- No foreign key, object might not exist at this point.
+
+    user_agent varchar(255) NOT NULL, -- From submitting client; allows migrations after upgrades.
+    state smallint NOT NULL DEFAULT 0, -- pending (0), processing (1), done (2), or error (64).
+
+    CONSTRAINT pk_event_queue PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE INDEX idx_event_queue_time ON event_queue (time);
+CREATE INDEX idx_event_queue_time_state ON event_queue (time, state);
+CREATE INDEX idx_event_queue_state_object_id ON event_queue (state, object_id);
+
 CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username varchar(254) NOT NULL COLLATE utf8mb4_unicode_ci,

--- a/schema/mysql/upgrades/ha-init.sql
+++ b/schema/mysql/upgrades/ha-init.sql
@@ -1,0 +1,16 @@
+CREATE TABLE event_queue (
+    id binary(32) NOT NULL, -- SHA256 of JSON representation.
+
+    json longtext NOT NULL,
+    time bigint NOT NULL,
+    object_id binary(32) NOT NULL, -- No foreign key, object might not exist at this point.
+
+    user_agent varchar(255) NOT NULL, -- From submitting client; allows migrations after upgrades.
+    state smallint NOT NULL DEFAULT 0, -- pending (0), processing (1), done (2), or error (64).
+
+    CONSTRAINT pk_event_queue PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE INDEX idx_event_queue_time ON event_queue (time);
+CREATE INDEX idx_event_queue_time_state ON event_queue (time, state);
+CREATE INDEX idx_event_queue_state_object_id ON event_queue (state, object_id);

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -463,6 +463,23 @@ CREATE TABLE incident_history (
 CREATE INDEX idx_incident_history_time_type ON incident_history(time, type);
 COMMENT ON INDEX idx_incident_history_time_type IS 'Incident History ordered by time/type';
 
+CREATE TABLE event_queue (
+    id bytea NOT NULL, -- SHA256 of JSON representation.
+
+    json text NOT NULL,
+    time bigint NOT NULL,
+    object_id bytea NOT NULL, -- No foreign key, object might not exist at this point.
+
+    user_agent varchar(255) NOT NULL, -- From submitting client; allows migrations after upgrades.
+    state smallint NOT NULL DEFAULT 0, -- pending (0), processing (1), done (2), or error (64).
+
+    CONSTRAINT pk_event_queue PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_event_queue_time ON event_queue (time);
+CREATE INDEX idx_event_queue_time_state ON event_queue (time, state);
+CREATE INDEX idx_event_queue_state_object_id ON event_queue (state, object_id);
+
 CREATE TABLE browser_session (
     php_session_id varchar(256) NOT NULL,
     username citext NOT NULL,

--- a/schema/pgsql/upgrades/ha-init.sql
+++ b/schema/pgsql/upgrades/ha-init.sql
@@ -1,0 +1,16 @@
+CREATE TABLE event_queue (
+    id bytea NOT NULL, -- SHA256 of JSON representation.
+
+    json text NOT NULL,
+    time bigint NOT NULL,
+    object_id bytea NOT NULL, -- No foreign key, object might not exist at this point.
+
+    user_agent varchar(255) NOT NULL, -- From submitting client; allows migrations after upgrades.
+    state smallint NOT NULL DEFAULT 0, -- pending (0), processing (1), done (2), or error (64).
+
+    CONSTRAINT pk_event_queue PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_event_queue_time ON event_queue (time);
+CREATE INDEX idx_event_queue_time_state ON event_queue (time, state);
+CREATE INDEX idx_event_queue_state_object_id ON event_queue (state, object_id);


### PR DESCRIPTION
    incident: Synchronize Incidents with the database

    For the upcoming HA functionality, incidents will change during Icinga
    Notification's runtime. To reflect this architectural change, database
    synchronizations will now be performed when processing events.

---

    Implement HA for Distributed Setups

    With this change, Icinga Notifications can now be used in distributed
    setups with multiple Icinga Notifications nodes. The relational database
    is used as an event queue where submitted events are first placed, and
    picked up from later.

    The main burden of a distributed setup or high availability was placed
    on to the database. Similar as in Icinga DB, transactions are used to
    ensure only one node wins. However, for Notifications, no single leader
    was elected, but a work queue was constructed where multiple nodes might
    enqueue events and dequeue events. A lock is only hold for the oldest
    event, allowing other nodes to access subsequent events.

    A more minor change is that the HTTP API now returns a 202 on event
    submission, and not after the event was processed. By doing so,
    superfluous events will also return 202 and not 406, as the evaluation
    happens after the event was pulled from the queue.

---

Fixes #394.