### PR TITLE
schema: Fix invalid references during `incident_contact` upgrade

### DIFF
--- a/schema/mysql/upgrades/incident-contact-changed_at.sql
+++ b/schema/mysql/upgrades/incident-contact-changed_at.sql
@@ -7,4 +7,5 @@ UPDATE incident_contact
     AND COALESCE(ih.schedule_id, 0) = COALESCE(incident_contact.schedule_id, 0)
   )
   SET incident_contact.changed_at = ih.time;
+UPDATE incident_contact SET changed_at = UNIX_TIMESTAMP() * 1000 WHERE changed_at IS NULL;
 ALTER TABLE incident_contact MODIFY COLUMN changed_at bigint NOT NULL;

--- a/schema/pgsql/upgrades/incident-contact-changed_at.sql
+++ b/schema/pgsql/upgrades/incident-contact-changed_at.sql
@@ -11,4 +11,5 @@ UPDATE incident_contact SET changed_at = ih.time
     COALESCE(incident_contact.contactgroup_id, 0),
     COALESCE(incident_contact.schedule_id, 0)
   );
+UPDATE incident_contact SET changed_at = EXTRACT(EPOCH from NOW()) * 1000 WHERE changed_at IS NULL;
 ALTER TABLE incident_contact ALTER COLUMN changed_at SET NOT NULL;


### PR DESCRIPTION
This happens in case schedules or contact groups are configured as recipients and so resolved contacts appear in the history but are not registered as incident contact.