### PR TITLE
Add startup bootstrap configuration

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/icinga/icinga-notifications/internal/daemon"
 	"github.com/icinga/icinga-notifications/internal/incident"
 	"github.com/icinga/icinga-notifications/internal/listener"
+	"github.com/icinga/icinga-notifications/internal/source"
+	"github.com/icinga/icinga-notifications/schema"
 	"github.com/okzk/sdnotify"
 	"os/signal"
 	"syscall"
@@ -44,8 +46,16 @@ func main() {
 		logger.Fatalf("Cannot connect to the database: %+v", err)
 	}
 
+	if err := schema.Ensure(ctx, db, logs.GetChildLogger("database")); err != nil {
+		logger.Fatalf("Failed to initialize database schema: %+v", err)
+	}
+
 	if err := internal.CheckSchema(ctx, db); err != nil {
 		logger.Fatalf("%+v", err)
+	}
+
+	if err := source.SyncConfigured(ctx, db, conf.Source, logger); err != nil {
+		logger.Fatalf("Failed to synchronize configured source: %+v", err)
 	}
 
 	channel.UpsertPlugins(ctx, conf.ChannelsDir, logs.GetChildLogger("channel"), db)

--- a/config.example.yml
+++ b/config.example.yml
@@ -37,6 +37,18 @@ listener:
   # Required if TLS is enabled to be able to verify client certificate if the client provides one.
   #ca: /path/to/ca.crt
 
+# Optional source bootstrap configuration.
+# When set, the daemon creates or updates these source entries in the database on startup.
+#source:
+#  - type: icingadb
+#    name: Icinga DB
+#    username: source-icingadb
+#    password_file: /run/secrets/icinga_notifications_icingadb_source_password
+#  - type: icinga-kubernetes
+#    name: Icinga for Kubernetes
+#    username: source-icinga-kubernetes
+#    password_file: /run/secrets/icinga_notifications_icinga_kubernetes_source_password
+
 # Connection configuration for the database where Icinga Notifications stores configuration and historical data.
 # This is also the database used in Icinga Notifications Web to view and work with the data.
 database:

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -40,6 +40,51 @@ For a package installation, the default will point to the correct location and m
 This directory should be `/usr/libexec/icinga-notifications/channels` on systems that follow the Filesystem Hierarchy Standard.
 It may also be `/usr/lib/icinga-notifications/channels`, depending on the operating system conventions.
 
+## Source Bootstrap Configuration
+
+Source entries are part of the database-backed Icinga Notifications configuration.
+They are usually managed through Icinga Notifications Web.
+For automated or headless setups, the daemon can create or update source entries from its own configuration on startup.
+
+For YAML configuration, the options are part of the `source` list.
+For environment variables, each source entry is indexed below the `ICINGA_NOTIFICATIONS_SOURCE_` prefix.
+
+| Option        | Description                                                                 |
+|---------------|-----------------------------------------------------------------------------|
+| type          | **Required.** Source type, for example `icingadb`.                          |
+| name          | **Required.** Display name of the source.                                   |
+| username      | **Required.** Username expected via HTTP Basic Authentication from the source. |
+| password      | **Optional.** Password expected via HTTP Basic Authentication from the source. |
+| password_file | **Optional.** Source password file.                                         |
+
+`password` or `password_file` must be set for each configured source.
+The password is stored as a bcrypt hash in the database.
+Each configured source must use a unique `username`.
+
+```yaml
+# YAML Configuration File
+source:
+  - type: icingadb
+    name: Icinga DB
+    username: source-icingadb
+    password_file: /run/secrets/icinga_notifications_icingadb_source_password
+  - type: icinga-kubernetes
+    name: Icinga for Kubernetes
+    username: source-icinga-kubernetes
+    password_file: /run/secrets/icinga_notifications_icinga_kubernetes_source_password
+```
+
+```
+# Environment Variables
+ICINGA_NOTIFICATIONS_SOURCE_0_TYPE=icingadb
+ICINGA_NOTIFICATIONS_SOURCE_0_NAME="Icinga DB"
+ICINGA_NOTIFICATIONS_SOURCE_0_USERNAME=source-icingadb
+ICINGA_NOTIFICATIONS_SOURCE_0_PASSWORD_FILE=/run/secrets/icinga_notifications_icingadb_source_password
+ICINGA_NOTIFICATIONS_SOURCE_1_TYPE=icinga-kubernetes
+ICINGA_NOTIFICATIONS_SOURCE_1_NAME="Icinga for Kubernetes"
+ICINGA_NOTIFICATIONS_SOURCE_1_USERNAME=source-icinga-kubernetes
+ICINGA_NOTIFICATIONS_SOURCE_1_PASSWORD_FILE=/run/secrets/icinga_notifications_icinga_kubernetes_source_password
+```
 ## HTTP API Configuration
 
 Configuration of the HTTP API listener for event submission and debugging endpoints.

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/icinga/icinga-go-library/utils"
 	"github.com/icinga/icinga-notifications/internal"
+	"github.com/icinga/icinga-notifications/internal/source"
 )
 
 const (
@@ -56,6 +57,7 @@ type ConfigFile struct {
 	ChannelsDir   string          `yaml:"channels_dir" env:"CHANNELS_DIR"`
 	Icingaweb2URL string          `yaml:"icingaweb2_url" env:"ICINGAWEB2_URL"`
 	Listener      Listener        `yaml:"listener" envPrefix:"LISTENER_"`
+	Source        []source.Config `yaml:"source" envPrefix:"SOURCE_"`
 	Database      database.Config `yaml:"database" envPrefix:"DATABASE_"`
 	Logging       logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
 
@@ -77,6 +79,9 @@ func (c *ConfigFile) SetDefaults() {
 // Validates the entire daemon configuration on daemon startup.
 func (c *ConfigFile) Validate() error {
 	if err := c.Listener.Validate(); err != nil {
+		return err
+	}
+	if err := source.Validate(c.Source); err != nil {
 		return err
 	}
 	if err := c.Database.Validate(); err != nil {
@@ -110,6 +115,7 @@ func (c *ConfigFile) Validate() error {
 var (
 	_ defaults.Setter  = (*ConfigFile)(nil)
 	_ config.Validator = (*ConfigFile)(nil)
+	_ config.Validator = (*source.Config)(nil)
 )
 
 // Flags defines the CLI flags supported by Icinga Notifications.

--- a/internal/source/config.go
+++ b/internal/source/config.go
@@ -1,0 +1,51 @@
+package source
+
+import (
+	"fmt"
+
+	"github.com/icinga/icinga-go-library/config"
+)
+
+type Config struct {
+	Type         string `yaml:"type" json:"type" env:"TYPE"`
+	Name         string `yaml:"name" json:"name" env:"NAME"`
+	Username     string `yaml:"username" json:"username" env:"USERNAME"`
+	Password     string `yaml:"password" json:"password" env:"PASSWORD"`
+	PasswordFile string `yaml:"password_file" json:"password_file" env:"PASSWORD_FILE"`
+}
+
+func (c *Config) Validate() error {
+	if err := config.LoadPasswordFile(&c.Password, c.PasswordFile); err != nil {
+		return err
+	}
+
+	if c.Type == "" {
+		return fmt.Errorf("source.type is required when source configuration is set")
+	}
+	if c.Name == "" {
+		return fmt.Errorf("source.name is required when source configuration is set")
+	}
+	if c.Username == "" {
+		return fmt.Errorf("source.username is required when source configuration is set")
+	}
+	if c.Password == "" {
+		return fmt.Errorf("source.password or source.password_file is required when source configuration is set")
+	}
+
+	return nil
+}
+
+func Validate(config []Config) error {
+	seenUsernames := make(map[string]struct{}, len(config))
+	for i := range config {
+		if err := config[i].Validate(); err != nil {
+			return fmt.Errorf("source.%d: %w", i, err)
+		}
+		if _, ok := seenUsernames[config[i].Username]; ok {
+			return fmt.Errorf("source.%d: duplicate source username %q", i, config[i].Username)
+		}
+		seenUsernames[config[i].Username] = struct{}{}
+	}
+
+	return nil
+}

--- a/internal/source/sync.go
+++ b/internal/source/sync.go
@@ -1,0 +1,101 @@
+package source
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/icinga/icinga-go-library/database"
+	"github.com/icinga/icinga-go-library/logging"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type configuredRow struct {
+	ID                   int64          `db:"id"`
+	Type                 string         `db:"type"`
+	Name                 string         `db:"name"`
+	ListenerPasswordHash sql.NullString `db:"listener_password_hash"`
+}
+
+func SyncConfigured(ctx context.Context, db *database.DB, config []Config, logger *logging.Logger) error {
+	for _, source := range config {
+		if err := syncConfigured(ctx, db, source, logger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func syncConfigured(ctx context.Context, db *database.DB, source Config, logger *logging.Logger) error {
+	existing, err := getConfigured(ctx, db, source.Username)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UnixMilli()
+	if existing == nil {
+		hash, err := bcrypt.GenerateFromPassword([]byte(source.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("can't hash source password: %w", err)
+		}
+
+		stmt := db.Rebind(`
+			INSERT INTO "source" ("type", "name", "listener_username", "listener_password_hash", "changed_at")
+			VALUES (?, ?, ?, ?, ?)`)
+		if _, err := db.ExecContext(ctx, stmt, source.Type, source.Name, source.Username, string(hash), now); err != nil {
+			return fmt.Errorf("can't create configured source %q: %w", source.Username, err)
+		}
+
+		logger.Infow("Created configured source", zap.String("source", source.Name), zap.String("username", source.Username))
+		return nil
+	}
+
+	passwordHash := existing.ListenerPasswordHash.String
+	if !existing.ListenerPasswordHash.Valid ||
+		bcrypt.CompareHashAndPassword([]byte(existing.ListenerPasswordHash.String), []byte(source.Password)) != nil {
+		hash, err := bcrypt.GenerateFromPassword([]byte(source.Password), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("can't hash source password: %w", err)
+		}
+
+		passwordHash = string(hash)
+	}
+
+	if existing.Type == source.Type && existing.Name == source.Name && existing.ListenerPasswordHash.Valid &&
+		existing.ListenerPasswordHash.String == passwordHash {
+		logger.Debugw("Configured source already up to date", zap.String("source", source.Name), zap.String("username", source.Username))
+		return nil
+	}
+
+	stmt := db.Rebind(`
+		UPDATE "source"
+		SET "type" = ?, "name" = ?, "listener_password_hash" = ?, "changed_at" = ?
+		WHERE "id" = ?`)
+	if _, err := db.ExecContext(ctx, stmt, source.Type, source.Name, passwordHash, now, existing.ID); err != nil {
+		return fmt.Errorf("can't update configured source %q: %w", source.Username, err)
+	}
+
+	logger.Infow("Updated configured source", zap.String("source", source.Name), zap.String("username", source.Username))
+	return nil
+}
+
+func getConfigured(ctx context.Context, db *database.DB, username string) (*configuredRow, error) {
+	stmt := db.Rebind(`
+		SELECT "id", "type", "name", "listener_password_hash"
+		FROM "source"
+		WHERE "listener_username" = ? AND "deleted" = 'n'`)
+
+	var source configuredRow
+	if err := db.GetContext(ctx, &source, stmt, username); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("can't load configured source %q: %w", username, err)
+	}
+
+	return &source, nil
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,323 @@
+package schema
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/icinga/icinga-go-library/database"
+	"github.com/icinga/icinga-go-library/logging"
+)
+
+const expectedVersion = "v1.0"
+
+var upgrades = []string{}
+
+//go:embed mysql/schema.sql mysql/upgrades/*.sql pgsql/schema.sql pgsql/upgrades/*.sql
+var files embed.FS
+
+// Ensure imports or updates the database schema to the version supported by this daemon.
+func Ensure(ctx context.Context, db *database.DB, logger *logging.Logger) error {
+	hasSchema, err := db.HasTable(ctx, "notifications_schema")
+	if err != nil {
+		return err
+	}
+
+	if hasSchema {
+		version, err := latestVersion(ctx, db)
+		if err != nil {
+			return err
+		}
+
+		return update(ctx, db, logger, version)
+	}
+
+	hasBaseSchema, err := db.HasTable(ctx, "source")
+	if err != nil {
+		return err
+	}
+	if !hasBaseSchema {
+		logger.Info("Importing database schema")
+
+		schema, err := readSchema(db.DriverName())
+		if err != nil {
+			return err
+		}
+
+		return execStatements(ctx, db, schema)
+	}
+
+	isCurrentSchema, err := hasColumn(ctx, db, "source", "listener_username")
+	if err != nil {
+		return err
+	}
+	if isCurrentSchema {
+		logger.Info("Recording database schema version")
+
+		return createVersionTable(ctx, db, expectedVersion)
+	}
+
+	return update(ctx, db, logger, "")
+}
+
+func latestVersion(ctx context.Context, db *database.DB) (string, error) {
+	var version string
+	query := "SELECT version FROM notifications_schema ORDER BY id DESC LIMIT 1"
+	if err := db.QueryRowxContext(ctx, query).Scan(&version); err != nil {
+		return "", database.CantPerformQuery(err, query)
+	}
+
+	return version, nil
+}
+
+func update(ctx context.Context, db *database.DB, logger *logging.Logger, currentVersion string) error {
+	if currentVersion == expectedVersion {
+		return nil
+	}
+	if currentVersion != "" && len(upgrades) == 0 {
+		return fmt.Errorf("unexpected database schema version %q, expected %q", currentVersion, expectedVersion)
+	}
+
+	applied := currentVersion
+	for _, version := range upgrades {
+		shouldApply := currentVersion == ""
+		if !shouldApply {
+			cmp, err := compareVersions(currentVersion, version)
+			if err != nil {
+				return err
+			}
+			shouldApply = cmp < 0
+		}
+		if !shouldApply {
+			continue
+		}
+
+		logger.Infof("Updating database schema to %s", version)
+
+		upgrade, err := readUpgrade(db.DriverName(), version)
+		if err != nil {
+			return err
+		}
+		if err := execStatements(ctx, db, upgrade); err != nil {
+			return err
+		}
+
+		applied = version
+	}
+
+	if applied != expectedVersion {
+		return fmt.Errorf("no database schema upgrade path from %q to %q", currentVersion, expectedVersion)
+	}
+
+	return nil
+}
+
+func createVersionTable(ctx context.Context, db *database.DB, version string) error {
+	switch db.DriverName() {
+	case database.MySQL:
+		createStmt := `CREATE TABLE IF NOT EXISTS notifications_schema (
+    id int NOT NULL AUTO_INCREMENT,
+    version varchar(64) NOT NULL,
+    timestamp bigint NOT NULL,
+
+    CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+    CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`
+		if _, err := db.ExecContext(ctx, createStmt); err != nil {
+			return database.CantPerformQuery(err, createStmt)
+		}
+
+		insertStmt := "INSERT INTO notifications_schema (version, timestamp) VALUES (?, UNIX_TIMESTAMP() * 1000)"
+		if _, err := db.ExecContext(ctx, insertStmt, version); err != nil {
+			return database.CantPerformQuery(err, insertStmt)
+		}
+	case database.PostgreSQL:
+		createStmt := `CREATE TABLE IF NOT EXISTS notifications_schema (
+    id serial,
+    version varchar(64) NOT NULL,
+    timestamp bigint NOT NULL,
+
+    CONSTRAINT pk_notifications_schema PRIMARY KEY (id),
+    CONSTRAINT uk_notifications_schema_version UNIQUE (version)
+)`
+		if _, err := db.ExecContext(ctx, createStmt); err != nil {
+			return database.CantPerformQuery(err, createStmt)
+		}
+
+		insertStmt := "INSERT INTO notifications_schema (version, timestamp) VALUES ($1, floor(extract(epoch from current_timestamp) * 1000)::bigint)"
+		if _, err := db.ExecContext(ctx, insertStmt, version); err != nil {
+			return database.CantPerformQuery(err, insertStmt)
+		}
+	default:
+		return fmt.Errorf("unsupported database driver %q", db.DriverName())
+	}
+
+	return nil
+}
+
+func hasColumn(ctx context.Context, db *database.DB, table, column string) (bool, error) {
+	var tableSchemaFunc string
+	switch db.DriverName() {
+	case database.MySQL:
+		tableSchemaFunc = "DATABASE()"
+	case database.PostgreSQL:
+		tableSchemaFunc = "CURRENT_SCHEMA()"
+	default:
+		return false, fmt.Errorf("unsupported database driver %q", db.DriverName())
+	}
+
+	query := db.Rebind("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=" + tableSchemaFunc + " AND TABLE_NAME=? AND COLUMN_NAME=?")
+	rows, err := db.QueryContext(ctx, query, table, column)
+	if err != nil {
+		return false, database.CantPerformQuery(err, query)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return rows.Next(), rows.Err()
+}
+
+func execStatements(ctx context.Context, db *database.DB, statements string) error {
+	for _, statement := range splitStatements(db.DriverName(), statements) {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return database.CantPerformQuery(err, statement)
+		}
+	}
+
+	return nil
+}
+
+func splitStatements(driverName, statements string) []string {
+	if driverName == database.MySQL {
+		return database.MysqlSplitStatements(statements)
+	}
+
+	return splitPostgreSQLStatements(statements)
+}
+
+func splitPostgreSQLStatements(sql string) []string {
+	var result []string
+	var start int
+	var quote rune
+	var dollarQuote string
+
+	for i := 0; i < len(sql); i++ {
+		if dollarQuote != "" {
+			if strings.HasPrefix(sql[i:], dollarQuote) {
+				i += len(dollarQuote) - 1
+				dollarQuote = ""
+			}
+			continue
+		}
+		if quote != 0 {
+			if rune(sql[i]) == quote {
+				if i+1 < len(sql) && sql[i+1] == sql[i] {
+					i++
+				} else {
+					quote = 0
+				}
+			}
+			continue
+		}
+
+		switch sql[i] {
+		case '\'', '"':
+			quote = rune(sql[i])
+		case '$':
+			if tag := readDollarQuote(sql[i:]); tag != "" {
+				dollarQuote = tag
+				i += len(tag) - 1
+			}
+		case ';':
+			if statement := strings.TrimSpace(sql[start:i]); statement != "" {
+				result = append(result, statement)
+			}
+			start = i + 1
+		}
+	}
+
+	if statement := strings.TrimSpace(sql[start:]); statement != "" {
+		result = append(result, statement)
+	}
+
+	return result
+}
+
+var dollarQuoteRe = regexp.MustCompile(`^\$[A-Za-z_][A-Za-z_0-9]*\$|^\$\$`)
+
+func readDollarQuote(sql string) string {
+	return dollarQuoteRe.FindString(sql)
+}
+
+func compareVersions(a, b string) (int, error) {
+	av, err := parseVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	bv, err := parseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+
+	for i := range av {
+		if av[i] < bv[i] {
+			return -1, nil
+		}
+		if av[i] > bv[i] {
+			return 1, nil
+		}
+	}
+
+	return 0, nil
+}
+
+func parseVersion(version string) ([3]int, error) {
+	var parsed [3]int
+	parts := strings.Split(version, ".")
+	if len(parts) != len(parsed) {
+		return parsed, fmt.Errorf("invalid database schema version %q", version)
+	}
+
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return parsed, fmt.Errorf("invalid database schema version %q", version)
+		}
+		parsed[i] = n
+	}
+
+	return parsed, nil
+}
+
+func readSchema(driverName string) (string, error) {
+	switch driverName {
+	case database.MySQL:
+		return read("mysql/schema.sql")
+	case database.PostgreSQL:
+		return read("pgsql/schema.sql")
+	default:
+		return "", fmt.Errorf("unsupported database driver %q", driverName)
+	}
+}
+
+func readUpgrade(driverName, version string) (string, error) {
+	switch driverName {
+	case database.MySQL:
+		return read("mysql/upgrades/" + version + ".sql")
+	case database.PostgreSQL:
+		return read("pgsql/upgrades/" + version + ".sql")
+	default:
+		return "", fmt.Errorf("unsupported database driver %q", driverName)
+	}
+}
+
+func read(name string) (string, error) {
+	content, err := files.ReadFile(name)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}


### PR DESCRIPTION
## Summary

This adds optional startup bootstrap support for automated and headless Icinga Notifications deployments.

The daemon can now prepare the database schema on startup and synchronize configured source entries before the normal runtime configuration is loaded. This allows Icinga Notifications to start in automated container environments without requiring manual pre-initialization through SQL imports or source creation in Icinga Notifications Web.

## Motivation

In automated deployments, especially container platforms such as OpenShift, the daemon is often expected to start from declarative deployment configuration only. Before this change, the database schema had to be imported separately and source entries had to be created manually through the web UI before the daemon could run successfully.

This PR makes that bootstrap step part of the daemon startup flow while keeping it optional. Deployments may provide database settings and source bootstrap settings through the existing configuration loading mechanism, including environment variables. With that in place, the daemon can initialize or verify the schema, create or update the configured sources, load channels, and start serving without manual interaction.

Manual workflows remain supported. Operators may still import the schema themselves before starting the daemon and may still manage sources through Icinga Notifications Web.

## What Changed

A new schema bootstrap step runs after the database connection is established and before the existing schema version check.

It handles these cases:

- imports the embedded schema when the database is empty
- reads and validates the recorded schema version when `notifications_schema` already exists
- records the current expected schema version for already initialized current schemas that do not yet have a `notifications_schema` table
- keeps the existing schema version check as the final guard

A new optional source bootstrap configuration allows the daemon to create or update source entries on startup.

For each configured source, the daemon validates the required fields, loads the password or password file, hashes the listener password with bcrypt, and synchronizes the matching active source entry by listener username.

## Scope

This PR only contains the runtime bootstrap behavior, configuration parsing, and documentation.

It intentionally does not include deployment-specific container image changes, CI/Tekton changes, or customer-specific build logic.

## Testing

Validated in an OpenShift deployment with automatic rollout.

The daemon started without manual interaction, initialized or verified the database schema before the existing schema check, synchronized the configured sources, loaded channels, and started the listener successfully.

```
2026-06-25T22:56:44.429Z INFO icinga-notifications Starting Icinga Notifications daemon (0.2.0-gb28a7ba)
2026-06-25T22:56:44.430Z INFO icinga-notifications Connecting to database at 'pgsql://icinganotifications@postgres-notifications:5432/icinganotifications'
2026-06-25T22:56:44.571Z INFO database Importing database schema
2026-06-25T22:56:46.654Z INFO icinga-notifications Created configured source {"source": "Icinga DB", "username": "icinganotifications-icingadb"}
2026-06-25T22:56:46.741Z INFO icinga-notifications Created configured source {"source": "Icinga for Kubernetes", "username": "icinganotifications-kubernetes"}
2026-06-25T22:56:46.753Z INFO channel Successfully updated 3 available channel types: email, rocketchat, webhook
2026-06-25T22:56:46.765Z INFO runtime-updates Applied configuration updates {"table": "source", "took": "7.355µs", "faulty_elements": 0, "deleted_unknown_elements": 0, "deleted_elements": 0, "updated_elements": 0, "new_elements": 2}
2026-06-25T22:56:46.765Z INFO incident Loading all active incidents from database
2026-06-25T22:56:46.766Z INFO listener Starting listener on http://:5680
```