### PR TITLE
GHA: drop unsupported MariaDB versions from the job matrix

### DIFF
--- a/.github/workflows/tests_with_database.yml
+++ b/.github/workflows/tests_with_database.yml
@@ -18,9 +18,6 @@ jobs:
           - mysql:8.0
           - mysql:8
           - mysql:latest
-          - mariadb:10.2
-          - mariadb:10.3
-          - mariadb:10.4
           - mariadb:10.5
           - mariadb:10.6
           - mariadb:10


### PR DESCRIPTION
In our installation docs states the least supported MariaDB version is 10.5.0, so dropping 10.2, 10.3, and 10.4 from the job matrix.