### PR TITLE
Fix resource leak and logging madness

### DIFF
--- a/cmd/icinga-notifications/main.go
+++ b/cmd/icinga-notifications/main.go
@@ -141,23 +141,16 @@ func run() int {
 						zap.String("event_name", ev.Name),
 						zap.Error(err))
 					return nil
-				} else if err != nil {
-					logger.Errorw("Failed to successfully process event",
-						zap.String("event_name", ev.Name),
-						zap.Error(err))
-					return err
 				}
-
-				logger.Infow("Successfully processed event", zap.String("event_name", ev.Name))
-				return nil
+				return err
 			})
-		if err == nil || errors.Is(err, context.Canceled) {
-			logger.Info("Event queue processor has finished")
-			return nil
-		} else {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			logger.Errorf("Event queue processor has finished with an error: %+v", err)
 			return err
 		}
+
+		logger.Info("Event queue processor has finished")
+		return nil
 	})
 
 	// When Icinga Notifications is started by systemd, we've to notify systemd that we're ready.

--- a/internal/event/queue.go
+++ b/internal/event/queue.go
@@ -201,7 +201,6 @@ func ProcessQueue(
 			zap.Stringer("object_id", q.ObjectId))
 
 		callbackCtx, cancel := context.WithTimeout(ctx, time.Minute)
-		defer cancel()
 
 		if ev, err := q.toEvent(); err != nil {
 			logger.Errorw("Invalid event queue event cannot get decoded", zap.Stringer("id", q.ID), zap.Error(err))
@@ -213,6 +212,7 @@ func ProcessQueue(
 			logger.Debugw("Processed event from event queue", zap.Stringer("id", q.ID))
 			q.State = QueueStateDone
 		}
+		cancel()
 
 		err = retry.WithBackoff(
 			ctx,

--- a/internal/event/queue.go
+++ b/internal/event/queue.go
@@ -196,21 +196,24 @@ func ProcessQueue(
 			return fmt.Errorf("cannot fetch event from event queue: %w", err)
 		}
 
-		logger.Debugw("Claimed event queue entry for processing",
-			zap.Stringer("id", q.ID),
-			zap.Stringer("object_id", q.ObjectId))
-
 		callbackCtx, cancel := context.WithTimeout(ctx, time.Minute)
 
-		if ev, err := q.toEvent(); err != nil {
-			logger.Errorw("Invalid event queue event cannot get decoded", zap.Stringer("id", q.ID), zap.Error(err))
-			q.State = QueueStateError
-		} else if err = callback(callbackCtx, ev); err != nil {
-			logger.Errorw("Event queue event cannot be processed", zap.Stringer("id", q.ID), zap.Error(err))
+		ev, err := q.toEvent()
+		if err != nil {
+			logger.Errorw("Cannot recreate event from event queue entry", zap.Stringer("id", q.ID), zap.Error(err))
 			q.State = QueueStateError
 		} else {
-			logger.Debugw("Processed event from event queue", zap.Stringer("id", q.ID))
-			q.State = QueueStateDone
+			logger.Debugw("Claimed event queue entry for processing",
+				zap.Stringer("id", q.ID),
+				zap.Object("event", ev))
+
+			if err := callback(callbackCtx, ev); err != nil {
+				logger.Errorw("Failed to process event", zap.Stringer("id", q.ID), zap.Error(err))
+				q.State = QueueStateError
+			} else {
+				logger.Debugw("Successfully processed event", zap.Stringer("id", q.ID))
+				q.State = QueueStateDone
+			}
 		}
 		cancel()
 


### PR DESCRIPTION
This PR fixes a resource leak caused by an endless defer statement within an endless loop in the `event.ProcessQueue` function and removes a bunch of log statements for the same event processing logic at multiple places without containing any different contex.