### PR TITLE
incident: Fix deadlock errors in unittests

### DIFF
--- a/internal/incident/incidents_test.go
+++ b/internal/incident/incidents_test.go
@@ -119,11 +119,16 @@ func TestIncidents(t *testing.T) {
 
 			// Close all remaining incidents to clean up the database for the next test run.
 			pairCh, errCh = Yield(t.Context(), db, logs, runtimeConfig)
+			var incidentPairs []Pair
 			for pair := range pairCh {
+				incidentPairs = append(incidentPairs, pair)
+			}
+			assert.NoError(t, <-errCh)
+
+			for _, pair := range incidentPairs {
 				require.NoError(t, ProcessEvent(t.Context(), db, logs, runtimeConfig, makeEvent(t, source.ID,
 					withIncident(), withClose(), withTags(pair.Object.Tags))))
 			}
-			assert.NoError(t, <-errCh)
 
 			incidentsLen = 0
 			pairCh, errCh = Yield(t.Context(), db, logs, runtimeConfig)


### PR DESCRIPTION
Closing the incident while yielding that very same incident in the tests seems to cause deadlocks occassionally as can be [seen here](https://github.com/Icinga/icinga-notifications/actions/runs/31366100270/job/93384687994?pr=483). ~This is mostly because `incident.ProcessEvent` invokes `i.restoreState` to acquire an exclusive lock on the incident via `... FOR UPDATE` query, and fails to do so because the row is already in use by the running cursor used to yield it.~ Wrong, otherwise the tests would've always triggered it and not just occassionally.

```
[731](https://github.com/Icinga/icinga-notifications/actions/runs/31365177155/job/93381909556?pr=483#step:8:1732)
logger.go:146: 2026-08-10T07:31:16.912Z	ERROR	incident	Cannot insert incident closed history to the database	{"object": "4d9dd7f6640bd898bdf54cc735dda554d9333ecf", "incident": "#125", "error": "can't perform \"INSERT INTO \\\"incident_history\\\" (\\\"sent_at\\\", \\\"time\\\", \\\"old_severity\\\", \\\"message\\\", \\\"old_recipient_role\\\", \\\"contact_id\\\", \\\"new_severity\\\", \\\"schedule_id\\\", \\\"incident_id\\\", \\\"channel_id\\\", \\\"new_recipient_role\\\", \\\"notification_state\\\", \\\"rule_escalation_id\\\", \\\"rule_id\\\", \\\"type\\\", \\\"contactgroup_id\\\") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING id\": pq: deadlock detected (40P01)", "errorVerbose": "pq: deadlock detected (40P01)
can't perform \"INSERT INTO \\\"incident_history\\\" (\\\"sent_at\\\", \\\"time\\\", \\\"old_severity\\\", \\\"message\\\", \\\"old_recipient_role\\\", \\\"contact_id\\\", \\\"new_severity\\\", \\\"schedule_id\\\", \\\"incident_id\\\", \\\"channel_id\\\", \\\"new_recipient_role\\\", \\\"notification_state\\\", \\\"rule_escalation_id\\\", \\\"rule_id\\\", \\\"type\\\", \\\"contactgroup_id\\\") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING id\"github.com/icinga/icinga-go-library/database.CantPerformQuery    /home/runner/go/pkg/mod/github.com/icinga/icinga-go-library@v0.9.1-0.20260807080555-d0ef9693144d/database/utils.go:19
github.com/icinga/icinga-go-library/database.InsertObtainID
    /home/runner/go/pkg/mod/github.com/icinga/icinga-go-library@v0.9.1-0.20260807080555-d0ef9693144d/database/utils.go:69
github.com/icinga/icinga-notifications/internal/incident.(*HistoryRow).Sync
    /home/runner/work/icinga-notifications/icinga-notifications/internal/incident/db_types.go:86
github.com/icinga/icinga-notifications/internal/incident.(*Incident).Close
    /home/runner/work/icinga-notifications/icinga-notifications/internal/incident/incident.go:345
github.com/icinga/icinga-notifications/internal/incident.(*Incident).ProcessEvent
    /home/runner/work/icinga-notifications/icinga-notifications/internal/incident/incident.go:233
github.com/icinga/icinga-notifications/internal/incident.ProcessEvent
    /home/runner/work/icinga-notifications/icinga-notifications/internal/incident/incidents.go:61
github.com/icinga/icinga-notifications/internal/incident.TestIncidents.func4.2
    /home/runner/work/icinga-notifications/icinga-notifications/internal/incident/incidents_test.go:133
testing.tRunner
    /opt/hostedtoolcache/go/1.26.5/x64/src/testing/testing.go:2036
runtime.goexit
    /opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771"}
```