### PR TITLE
tests: load DB config from real env variables

### DIFF
--- a/.github/workflows/tests_with_database.yml
+++ b/.github/workflows/tests_with_database.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request: {}
 
+env:
+  ICINGA_NOTIFICATIONS_ICINGAWEB2_URL: https://localhost/icingaweb2
+  ICINGA_NOTIFICATIONS_DATABASE_DATABASE: notifications
+  ICINGA_NOTIFICATIONS_DATABASE_PASSWORD: notifications
+  ICINGA_NOTIFICATIONS_DATABASE_HOST: 127.0.0.1
+
 jobs:
   mysql:
     runs-on: ubuntu-latest
@@ -27,19 +33,16 @@ jobs:
           - mariadb:latest
 
     env:
-      NOTIFICATIONS_TESTS_DB_TYPE: mysql
-      NOTIFICATIONS_TESTS_DB: notifications
-      NOTIFICATIONS_TESTS_DB_USER: root
-      NOTIFICATIONS_TESTS_DB_PASSWORD: notifications
-      NOTIFICATIONS_TESTS_DB_HOST: 127.0.0.1
-      NOTIFICATIONS_TESTS_DB_PORT: 3306
+      ICINGA_NOTIFICATIONS_DATABASE_TYPE: mysql
+      ICINGA_NOTIFICATIONS_DATABASE_USER: root
+      ICINGA_NOTIFICATIONS_DATABASE_PORT: 3306
 
     services:
       mysql:
         image: ${{ matrix.image }}
         env:
-          MYSQL_ROOT_PASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
-          MYSQL_DATABASE: ${{ env.NOTIFICATIONS_TESTS_DB }}
+          MYSQL_ROOT_PASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
+          MYSQL_DATABASE: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_DATABASE }}
         # Wait until MySQL becomes ready
         options: >-
           --health-cmd "${{ (startsWith(matrix.image, 'mysql:') || startsWith(matrix.image, 'mariadb:10')) && 'mysqladmin ping' || 'healthcheck.sh --connect --innodb_initialized' }}"
@@ -60,8 +63,8 @@ jobs:
 
       - name: Importing Schema
         run: >
-          mysql -h127.0.0.1 -u$NOTIFICATIONS_TESTS_DB_USER -p$NOTIFICATIONS_TESTS_DB_PASSWORD
-          $NOTIFICATIONS_TESTS_DB < ${{ github.workspace }}/schema/mysql/schema.sql
+          mysql -h127.0.0.1 -u$ICINGA_NOTIFICATIONS_DATABASE_USER -p$ICINGA_NOTIFICATIONS_DATABASE_PASSWORD
+          $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < ${{ github.workspace }}/schema/mysql/schema.sql
 
       - name: Download dependencies
         run: go get -v -t -d ./...
@@ -80,19 +83,16 @@ jobs:
         version: ["9.6", "10", "11", "12", "13", "14", "15", "latest"]
 
     env:
-      NOTIFICATIONS_TESTS_DB_TYPE: pgsql
-      NOTIFICATIONS_TESTS_DB: notifications
-      NOTIFICATIONS_TESTS_DB_USER: postgres
-      NOTIFICATIONS_TESTS_DB_PASSWORD: notifications
-      NOTIFICATIONS_TESTS_DB_HOST: 127.0.0.1
-      NOTIFICATIONS_TESTS_DB_PORT: 5432
+      ICINGA_NOTIFICATIONS_DATABASE_TYPE: pgsql
+      ICINGA_NOTIFICATIONS_DATABASE_USER: postgres
+      ICINGA_NOTIFICATIONS_DATABASE_PORT: 5432
 
     services:
       postgres:
         image: postgres:${{ matrix.version }}
         env:
-          POSTGRES_PASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
-          POSTGRES_DB: ${{ env.NOTIFICATIONS_TESTS_DB }}
+          POSTGRES_PASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_DATABASE }}
         # Wait until postgres becomes ready
         options: >-
           --health-cmd pg_isready
@@ -113,9 +113,9 @@ jobs:
 
       - name: Importing Schema
         env:
-          PGPASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
+          PGPASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
         run: |
-          psql -U postgres -w -h 127.0.0.1 -d ${{ env.NOTIFICATIONS_TESTS_DB }} < ${{ github.workspace }}/schema/pgsql/schema.sql
+          psql -U postgres -w -h 127.0.0.1 -d ${{ env.ICINGA_NOTIFICATIONS_DATABASE_DATABASE }} < ${{ github.workspace }}/schema/pgsql/schema.sql
 
       - name: Download dependencies
         run: go get -v -t -d ./...

--- a/.github/workflows/tests_with_database.yml
+++ b/.github/workflows/tests_with_database.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request: {}
 
+env:
+  ICINGA_NOTIFICATIONS_ICINGAWEB2_URL: https://localhost/icingaweb2
+  ICINGA_NOTIFICATIONS_DATABASE_DATABASE: notifications
+  ICINGA_NOTIFICATIONS_DATABASE_PASSWORD: notifications
+  ICINGA_NOTIFICATIONS_DATABASE_HOST: 127.0.0.1
+
 jobs:
   mysql:
     runs-on: ubuntu-latest
@@ -27,19 +33,16 @@ jobs:
           - mariadb:latest
 
     env:
-      NOTIFICATIONS_TESTS_DB_TYPE: mysql
-      NOTIFICATIONS_TESTS_DB: notifications
-      NOTIFICATIONS_TESTS_DB_USER: root
-      NOTIFICATIONS_TESTS_DB_PASSWORD: notifications
-      NOTIFICATIONS_TESTS_DB_HOST: 127.0.0.1
-      NOTIFICATIONS_TESTS_DB_PORT: 3306
+      ICINGA_NOTIFICATIONS_DATABASE_TYPE: mysql
+      ICINGA_NOTIFICATIONS_DATABASE_USER: root
+      ICINGA_NOTIFICATIONS_DATABASE_PORT: 3306
 
     services:
       mysql:
         image: ${{ matrix.image }}
         env:
-          MYSQL_ROOT_PASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
-          MYSQL_DATABASE: ${{ env.NOTIFICATIONS_TESTS_DB }}
+          MYSQL_ROOT_PASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
+          MYSQL_DATABASE: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_DATABASE }}
         # Wait until MySQL becomes ready
         options: >-
           --health-cmd "${{ (startsWith(matrix.image, 'mysql:') || startsWith(matrix.image, 'mariadb:10')) && 'mysqladmin ping' || 'healthcheck.sh --connect --innodb_initialized' }}"
@@ -60,8 +63,8 @@ jobs:
 
       - name: Importing Schema
         run: >
-          mysql -h127.0.0.1 -u$NOTIFICATIONS_TESTS_DB_USER -p$NOTIFICATIONS_TESTS_DB_PASSWORD
-          $NOTIFICATIONS_TESTS_DB < ${{ github.workspace }}/schema/mysql/schema.sql
+          mysql -h$ICINGA_NOTIFICATIONS_DATABASE_HOST -u$ICINGA_NOTIFICATIONS_DATABASE_USER -p$ICINGA_NOTIFICATIONS_DATABASE_PASSWORD
+          $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < ${{ github.workspace }}/schema/mysql/schema.sql
 
       - name: Download dependencies
         run: go get -v -t -d ./...
@@ -80,19 +83,16 @@ jobs:
         version: ["9.6", "10", "11", "12", "13", "14", "15", "latest"]
 
     env:
-      NOTIFICATIONS_TESTS_DB_TYPE: pgsql
-      NOTIFICATIONS_TESTS_DB: notifications
-      NOTIFICATIONS_TESTS_DB_USER: postgres
-      NOTIFICATIONS_TESTS_DB_PASSWORD: notifications
-      NOTIFICATIONS_TESTS_DB_HOST: 127.0.0.1
-      NOTIFICATIONS_TESTS_DB_PORT: 5432
+      ICINGA_NOTIFICATIONS_DATABASE_TYPE: pgsql
+      ICINGA_NOTIFICATIONS_DATABASE_USER: postgres
+      ICINGA_NOTIFICATIONS_DATABASE_PORT: 5432
 
     services:
       postgres:
         image: postgres:${{ matrix.version }}
         env:
-          POSTGRES_PASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
-          POSTGRES_DB: ${{ env.NOTIFICATIONS_TESTS_DB }}
+          POSTGRES_PASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_DATABASE }}
         # Wait until postgres becomes ready
         options: >-
           --health-cmd pg_isready
@@ -113,9 +113,9 @@ jobs:
 
       - name: Importing Schema
         env:
-          PGPASSWORD: ${{ env.NOTIFICATIONS_TESTS_DB_PASSWORD }}
+          PGPASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
         run: |
-          psql -U postgres -w -h 127.0.0.1 -d ${{ env.NOTIFICATIONS_TESTS_DB }} < ${{ github.workspace }}/schema/pgsql/schema.sql
+          psql -U postgres -w -h$ICINGA_NOTIFICATIONS_DATABASE_HOST -d $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < ${{ github.workspace }}/schema/pgsql/schema.sql
 
       - name: Download dependencies
         run: go get -v -t -d ./...

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/creasty/defaults"
@@ -251,9 +252,12 @@ func (f Flags) IsExplicitConfigPath() bool {
 	return f.Config != ""
 }
 
-// daemonConfig holds the configuration state as a singleton.
-// It is initialised by the ParseFlagsAndConfig func and exposed through the Config function.
-var daemonConfig *ConfigFile
+var (
+	// daemonConfig holds the configuration state as a singleton.
+	// It is initialised by the ParseFlagsAndConfig func and exposed through the Config function.
+	daemonConfig   *ConfigFile
+	initConfigOnce sync.Once
+)
 
 // Config returns the config that was loaded while starting the daemon.
 // Panics when ParseFlagsAndConfig was not called earlier.
@@ -282,8 +286,8 @@ func ParseFlagsAndConfig() {
 		os.Exit(ExitSuccess)
 	}
 
-	daemonConfig = new(ConfigFile)
-	if err := config.Load(daemonConfig, config.LoadOptions{
+	conf := new(ConfigFile)
+	if err := config.Load(conf, config.LoadOptions{
 		Flags:      flags,
 		EnvOptions: config.EnvOptions{Prefix: "ICINGA_NOTIFICATIONS_"},
 	}); err != nil {
@@ -293,4 +297,8 @@ func ParseFlagsAndConfig() {
 
 		utils.PrintErrorThenExit(err, ExitFailure)
 	}
+	initConfigOnce.Do(func() { daemonConfig = conf })
 }
+
+// SetTestConfig sets the global daemon config instance for testing purposes.
+func SetTestConfig(conf *ConfigFile) { initConfigOnce.Do(func() { daemonConfig = conf }) }

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/creasty/defaults"
@@ -251,9 +252,12 @@ func (f Flags) IsExplicitConfigPath() bool {
 	return f.Config != ""
 }
 
-// daemonConfig holds the configuration state as a singleton.
-// It is initialised by the ParseFlagsAndConfig func and exposed through the Config function.
-var daemonConfig *ConfigFile
+var (
+	// daemonConfig holds the configuration state as a singleton.
+	// It is initialised by the ParseFlagsAndConfig func and exposed through the Config function.
+	daemonConfig   *ConfigFile
+	initConfigOnce sync.Once
+)
 
 // Config returns the config that was loaded while starting the daemon.
 // Panics when ParseFlagsAndConfig was not called earlier.
@@ -282,8 +286,8 @@ func ParseFlagsAndConfig() {
 		os.Exit(ExitSuccess)
 	}
 
-	daemonConfig = new(ConfigFile)
-	if err := config.Load(daemonConfig, config.LoadOptions{
+	conf := new(ConfigFile)
+	if err := config.Load(conf, config.LoadOptions{
 		Flags:      flags,
 		EnvOptions: config.EnvOptions{Prefix: "ICINGA_NOTIFICATIONS_"},
 	}); err != nil {
@@ -293,4 +297,17 @@ func ParseFlagsAndConfig() {
 
 		utils.PrintErrorThenExit(err, ExitFailure)
 	}
+	initConfigOnce.Do(func() { daemonConfig = conf })
+}
+
+// InjectTestConfig allows tests to modify the daemon configuration before it is used.
+//
+// The provided function f is called with a pointer to the ConfigFile, allowing tests to set specific values.
+// It's safe for concurrent tests, and only the first call to InjectTestConfig will have an effect and any
+// subsequent calls will be ignored.
+func InjectTestConfig(f func(*ConfigFile)) {
+	initConfigOnce.Do(func() {
+		daemonConfig = new(ConfigFile)
+		f(daemonConfig)
+	})
 }

--- a/internal/incident/incidents_test.go
+++ b/internal/incident/incidents_test.go
@@ -12,6 +12,7 @@ import (
 	baseEv "github.com/icinga/icinga-go-library/notifications/event"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/config"
+	"github.com/icinga/icinga-notifications/internal/daemon"
 	"github.com/icinga/icinga-notifications/internal/event"
 	"github.com/icinga/icinga-notifications/internal/object"
 	"github.com/icinga/icinga-notifications/internal/rule"
@@ -19,18 +20,16 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestIncidents(t *testing.T) {
 	t.Parallel()
 
-	db := testutils.GetTestDB(t.Context(), t)
-	logs := logging.NewLoggingWithFactory("testing", zapcore.DebugLevel, time.Second, func(level zap.AtomicLevel) zapcore.Core {
-		return zaptest.NewLogger(t, zaptest.Level(level.Level())).Core()
+	db := testutils.GetTestDB(t.Context(), t, func(dc *daemon.ConfigFile) *database.Config {
+		daemon.SetTestConfig(dc)
+		return &dc.Database
 	})
+	logs := testutils.GetTestLogging(t)
 
 	// Insert a dummy source for our test cases!
 	source := &config.Source{

--- a/internal/incident/incidents_test.go
+++ b/internal/incident/incidents_test.go
@@ -12,6 +12,7 @@ import (
 	baseEv "github.com/icinga/icinga-go-library/notifications/event"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/config"
+	"github.com/icinga/icinga-notifications/internal/daemon"
 	"github.com/icinga/icinga-notifications/internal/event"
 	"github.com/icinga/icinga-notifications/internal/object"
 	"github.com/icinga/icinga-notifications/internal/rule"
@@ -19,18 +20,16 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestIncidents(t *testing.T) {
 	t.Parallel()
 
-	db := testutils.GetTestDB(t.Context(), t)
-	logs := logging.NewLoggingWithFactory("testing", zapcore.DebugLevel, time.Second, func(level zap.AtomicLevel) zapcore.Core {
-		return zaptest.NewLogger(t, zaptest.Level(level.Level())).Core()
-	})
+	// This will either load the test config from env vars or skip the test if the required env variable is not set.
+	daemon.InjectTestConfig(func(configFile *daemon.ConfigFile) { testutils.LoadTestConfig(t, configFile) })
+
+	db := testutils.GetTestDB(t.Context(), t, &daemon.Config().Database)
+	logs := testutils.GetTestLogging(t)
 
 	// Insert a dummy source for our test cases!
 	source := &config.Source{

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-notifications/internal/config"
+	"github.com/icinga/icinga-notifications/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -100,11 +99,7 @@ func makeTestListener(t *testing.T, useSocket bool, withCNSrc bool) *Listener {
 		}
 	}
 
-	logs := logging.NewLoggingWithFactory("testing", zapcore.DebugLevel, time.Second, func(level zap.AtomicLevel) zapcore.Core {
-		return zaptest.NewLogger(t, zaptest.Level(level.Level())).Core()
-	})
-
-	rc := config.NewRuntimeConfig(logs, nil)
+	rc := config.NewRuntimeConfig(testutils.GetTestLogging(t), nil)
 	rc.Sources = map[int64]*config.Source{1: src}
 
 	if withCNSrc {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -4,58 +4,50 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/creasty/defaults"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
-	"os"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
 )
 
-// GetTestDB retrieves the database config from env variables, opens a new database and returns it.
+// LoadTestConfig loads the configuration from environment variables into the provided config struct for testing purposes.
 //
-// The test suite will be skipped if no environment variable is set, otherwise fails fatally when
-// invalid configurations are specified.
-func GetTestDB(ctx context.Context, t *testing.T) *database.DB {
-	c := &database.Config{}
-	require.NoError(t, defaults.Set(c), "applying config default should not fail")
+// It requires the environment variable "ICINGA_NOTIFICATIONS_DATABASE_TYPE" to be set, otherwise it will
+// skip the test. The function validates the provided configuration struct and populates it with values
+// from the environment variables prefixed with "ICINGA_NOTIFICATIONS_".
+func LoadTestConfig[T config.Validator](t *testing.T, configFile T) {
+	if _, ok := os.LookupEnv("ICINGA_NOTIFICATIONS_DATABASE_TYPE"); !ok {
+		t.Skipf("Environment %q not set, skipping test!", "ICINGA_NOTIFICATIONS_DATABASE_TYPE")
+	}
+	require.NoError(t, config.FromEnv(configFile, config.EnvOptions{Prefix: "ICINGA_NOTIFICATIONS_"}))
+}
 
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_TYPE"); ok {
-		c.Type = strings.ToLower(v)
-	} else {
-		t.Skipf("Environment %q not set, skipping test!", "NOTIFICATIONS_TESTS_DB_TYPE")
-	}
-
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB"); ok {
-		c.Database = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_USER"); ok {
-		c.User = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_PASSWORD"); ok {
-		c.Password = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_HOST"); ok {
-		c.Host = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_PORT"); ok {
-		port, err := strconv.Atoi(v)
-		require.NoError(t, err, "invalid port provided")
-
-		c.Port = port
-	}
-
-	require.NoError(t, c.Validate(), "database config validation should not fail")
-
-	db, err := database.NewDbFromConfig(c, logging.NewLogger(zaptest.NewLogger(t).Sugar(), time.Hour), database.RetryConnectorCallbacks{})
+// GetTestDB returns a database.DB instance for testing purposes.
+//
+// It connects to the database using the provided configuration and ensures that the connection is successful.
+// If the connection or ping fails, it will fail the test.
+func GetTestDB(ctx context.Context, t *testing.T, dbConfig *database.Config) *database.DB {
+	db, err := database.NewDbFromConfig(dbConfig, logging.NewLogger(zaptest.NewLogger(t).Sugar(), time.Hour), database.RetryConnectorCallbacks{})
 	require.NoError(t, err, "connecting to database should not fail")
 	require.NoError(t, db.PingContext(ctx), "pinging the database should not fail")
 
 	return db
+}
+
+// GetTestLogging returns a logging.Logging instance for testing purposes.
+//
+// It sets the logging level to Debug and uses a zaptest logger to capture logs during tests.
+func GetTestLogging(t *testing.T) *logging.Logging {
+	return logging.NewLoggingWithFactory("testing", zapcore.DebugLevel, time.Second, func(level zap.AtomicLevel) zapcore.Core {
+		return zaptest.NewLogger(t, zaptest.Level(level.Level())).Core()
+	})
 }
 
 // MakeRandomString returns a 20 byte random hex string.

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -4,58 +4,48 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/creasty/defaults"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
-	"os"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
 )
 
-// GetTestDB retrieves the database config from env variables, opens a new database and returns it.
+// GetTestDB returns a database connection for testing purposes.
 //
-// The test suite will be skipped if no environment variable is set, otherwise fails fatally when
-// invalid configurations are specified.
-func GetTestDB(ctx context.Context, t *testing.T) *database.DB {
-	c := &database.Config{}
-	require.NoError(t, defaults.Set(c), "applying config default should not fail")
-
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_TYPE"); ok {
-		c.Type = strings.ToLower(v)
-	} else {
-		t.Skipf("Environment %q not set, skipping test!", "NOTIFICATIONS_TESTS_DB_TYPE")
+// It requires the environment variable "ICINGA_NOTIFICATIONS_DATABASE_TYPE" to be set, otherwise it will
+// skip the test. The function validates the provided database configuration, establishes a connection,
+// and pings the database to ensure it's reachable.
+func GetTestDB[T any](ctx context.Context, t *testing.T, visit func(*T) *database.Config) *database.DB {
+	if _, ok := os.LookupEnv("ICINGA_NOTIFICATIONS_DATABASE_TYPE"); !ok {
+		t.Skipf("Environment %q not set, skipping test!", "ICINGA_NOTIFICATIONS_DATABASE_TYPE")
 	}
 
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB"); ok {
-		c.Database = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_USER"); ok {
-		c.User = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_PASSWORD"); ok {
-		c.Password = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_HOST"); ok {
-		c.Host = v
-	}
-	if v, ok := os.LookupEnv("NOTIFICATIONS_TESTS_DB_PORT"); ok {
-		port, err := strconv.Atoi(v)
-		require.NoError(t, err, "invalid port provided")
+	conf := new(T)
+	validator, ok := any(conf).(config.Validator)
+	require.True(t, ok, "type must implement config.Validator")
 
-		c.Port = port
-	}
-
-	require.NoError(t, c.Validate(), "database config validation should not fail")
-
-	db, err := database.NewDbFromConfig(c, logging.NewLogger(zaptest.NewLogger(t).Sugar(), time.Hour), database.RetryConnectorCallbacks{})
+	require.NoError(t, config.FromEnv(validator, config.EnvOptions{Prefix: "ICINGA_NOTIFICATIONS_"}))
+	db, err := database.NewDbFromConfig(visit(conf), logging.NewLogger(zaptest.NewLogger(t).Sugar(), time.Hour), database.RetryConnectorCallbacks{})
 	require.NoError(t, err, "connecting to database should not fail")
 	require.NoError(t, db.PingContext(ctx), "pinging the database should not fail")
 
 	return db
+}
+
+// GetTestLogging returns a logging.Logging instance for testing purposes.
+//
+// It sets the logging level to Debug and uses a zaptest logger to capture logs during tests.
+func GetTestLogging(t *testing.T) *logging.Logging {
+	return logging.NewLoggingWithFactory("testing", zapcore.DebugLevel, time.Second, func(level zap.AtomicLevel) zapcore.Core {
+		return zaptest.NewLogger(t, zaptest.Level(level.Level())).Core()
+	})
 }
 
 // MakeRandomString returns a 20 byte random hex string.


### PR DESCRIPTION
The previously used env vars were introduced at the time where we didn't have a proper environment support for our config. Now, that we fully support configuring everything via env vars, the tests should also use the same env vars instead of requiring custom ones that needs to be parsed separately. The daemon config initialization is now wrapped in a sync.Once to prevent data races when running the tests in parallel both calling `daemon.SetConfigForTesting`.

The commit is cherry-picked from #483, so that it gets merged quickly and use it in other PRs as well.

Additionally, I've also moved the complex test logging construction from the incidents tests into its own `testutils.GetTestLogging` function to make it easier to use.