### PR TITLE
GHA: bump DB version matrix & replace PostgreSQL procedure with function

### DIFF
--- a/.github/workflows/tests_with_database.yml
+++ b/.github/workflows/tests_with_database.yml
@@ -22,6 +22,8 @@ jobs:
         image:
           - mysql:8.0
           - mysql:8
+          - mysql:9.0
+          - mysql:9
           - mysql:latest
           - mariadb:10.5
           - mariadb:10.6
@@ -29,6 +31,8 @@ jobs:
           - mariadb:11.0
           - mariadb:11.1
           - mariadb:11.2
+          - mariadb:12.0
+          - mariadb:12
           - mariadb:latest
 
     env:
@@ -84,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.6", "10", "11", "12", "13", "14", "15", "latest"]
+        version: ["9.6", "10", "11", "12", "13", "14", "15", "16", "17", "latest"]
 
     env:
       ICINGA_NOTIFICATIONS_DATABASE_TYPE: pgsql
@@ -119,7 +123,7 @@ jobs:
         env:
           PGPASSWORD: ${{ env.ICINGA_NOTIFICATIONS_DATABASE_PASSWORD }}
         run: |
-          psql -U postgres -w -h$ICINGA_NOTIFICATIONS_DATABASE_HOST -d $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < ${{ github.workspace }}/schema/pgsql/schema.sql
+          psql -v ON_ERROR_STOP=1 -U postgres -w -h$ICINGA_NOTIFICATIONS_DATABASE_HOST -d $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < ${{ github.workspace }}/schema/pgsql/schema.sql
 
       - name: Download dependencies
         run: go get -v -t -d ./...

--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -70,7 +70,7 @@ To apply these changes, run `systemctl reload postgresql`.
 After creating the database, import the Icinga Notifications schema using the following command:
 
 ```
-psql -U notifications notifications < /usr/share/icinga-notifications/schema/pgsql/schema.sql
+psql -v ON_ERROR_STOP=1 -U notifications notifications < /usr/share/icinga-notifications/schema/pgsql/schema.sql
 ```
 
 ## Configuring Icinga Notifications

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -31,17 +31,23 @@ CREATE OR REPLACE FUNCTION anynonarrayliketext(anynonarray, text)
     $$;
 CREATE OPERATOR ~~ (LEFTARG=anynonarray, RIGHTARG=text, PROCEDURE=anynonarrayliketext);
 
--- This procedure can be used in upgrade scripts to assert that the schema version in the database matches the
+-- This function can be used in upgrade scripts to assert that the schema version in the database matches the
 -- expected version before applying the upgrade. This is important to prevent users from accidentally skipping
 -- intermediate upgrade scripts, which could lead to an inconsistent database state. For instance, since every
--- upgrade script knows its predecessor's version, we can just do "CALL assert_correct_schema_version('v1.0')"
+-- upgrade script knows its predecessor's version, we can just do "SELECT assert_correct_schema_version('v1.0');"
 -- at the beginning of the 1.x upgrade scripts to ensure that the 1.0 script has been applied before.
-CREATE OR REPLACE PROCEDURE assert_correct_schema_version(expected_version text)
+CREATE OR REPLACE FUNCTION assert_correct_schema_version(expected_version text)
+    RETURNS void
     LANGUAGE plpgsql
+    STABLE
+    STRICT
+    PARALLEL RESTRICTED
 AS $$
 DECLARE
-    actual_version text := (SELECT version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1);
+    actual_version text;
 BEGIN
+    SELECT version INTO actual_version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1;
+
     IF actual_version IS NULL THEN
         RAISE 'Schema version not found in notifications_schema table.';
     ELSIF actual_version != expected_version THEN
@@ -49,7 +55,6 @@ BEGIN
     END IF;
 END;
 $$;
-COMMENT ON PROCEDURE assert_correct_schema_version IS 'Asserts that the schema version in the database matches the expected version and raises an error if not.';
 
 CREATE TABLE available_channel_type (
     type varchar(255) NOT NULL,

--- a/schema/pgsql/upgrades/procedure-to-function.sql
+++ b/schema/pgsql/upgrades/procedure-to-function.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION assert_correct_schema_version(expected_version text)
+    RETURNS void
+    LANGUAGE plpgsql
+    STABLE
+    STRICT
+    PARALLEL RESTRICTED
+AS $$
+DECLARE
+    actual_version text;
+BEGIN
+    SELECT version INTO actual_version FROM notifications_schema ORDER BY timestamp DESC LIMIT 1;
+
+    IF actual_version IS NULL THEN
+        RAISE 'Schema version not found in notifications_schema table.';
+    ELSIF actual_version != expected_version THEN
+        RAISE 'Schema version mismatch: expected %, got %. Please apply all previous upgrade scripts in order before applying this one.', expected_version, actual_version;
+    END IF;
+END;
+$$;


### PR DESCRIPTION
This PR bumps the DB version matrix for both DBMs. Additionally, it also replaces our existing PROCEDURE add in https://github.com/Icinga/icinga-notifications/pull/422 with a FUNCTION for PostgreSQL as our schema file is no longer compatible with PostgreSQL versions older than 11 anymore.

```bash

Run psql -U postgres -w -h$ICINGA_NOTIFICATIONS_DATABASE_HOST -d $ICINGA_NOTIFICATIONS_DATABASE_DATABASE < /home/runner/work/icinga-notifications/icinga-notifications/schema/pgsql/schema.sql
CREATE EXTENSION
CREATE TYPE
CREATE TYPE
CREATE TYPE
CREATE TYPE
CREATE TYPE
CREATE FUNCTION
CREATE OPERATOR
ERROR:  syntax error at or near "PROCEDURE"
LINE 1: CREATE OR REPLACE PROCEDURE assert_correct_schema_version(ex...
                          ^
ERROR:  syntax error at or near "PROCEDURE"
LINE 1: COMMENT ON PROCEDURE assert_correct_schema_version IS 'Asser...
                   ^
CREATE TABLE
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
```

Also, looking at the PostgreSQL documentation also shows that [this page](https://www.postgresql.org/docs/11/sql-createprocedure.html) describing the PROCDURE feature exists only since PostgreSQL version 11.