### PR TITLE
plugin: don't prematurely close RPC connection

### DIFF
--- a/internal/channel/plugin.go
+++ b/internal/channel/plugin.go
@@ -149,9 +149,8 @@ func newPluginSupervisor(ctx context.Context, db *database.DB, logger *zap.Sugar
 func (p *pluginSupervisor) Stop() {
 	p.logger.Debug("Stopping channel plugin process")
 
-	// Give the plugin a chance to clean up its resources and exit gracefully with the two friendly
-	// requests below (RPC-conn close and SIGTERM) before we forcefully kill it after a timeout.
-	_ = p.rpc.Conn().Close()
+	// Give the plugin a chance to clean up its resources and exit gracefully with the friendly
+	// request (SIGTERM) before we forcefully kill it after a timeout.
 	_ = p.cmd.Process.Signal(syscall.SIGTERM)
 
 	const timeout = 5 * time.Second
@@ -165,6 +164,7 @@ func (p *pluginSupervisor) Stop() {
 	} else {
 		p.logger.Infow("Channel plugin stopped successfully")
 	}
+	_ = p.rpc.Conn().Close()
 	p.cancel()
 	timer.Stop()
 }


### PR DESCRIPTION
The plugin tests sometimes crash with the following stack trace and I think, it's because the RPC connection was closed way too early before stopping the process. This PR defers this now untill the plugin process is fully terminated, allowing it to send any last messages before it gets killed. I've also created an upstream issue for this https://github.com/sourcegraph/jsonrpc2/issues/103.

This is from https://github.com/Icinga/icinga-notifications/actions/runs/34321119840/job/102367757728.
```bash
panic: send on closed channel

goroutine 4348 [running]:
github.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0xc9db3ae0e60, {0xd986c0, 0xc9db395fbd0})
	/home/runner/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.2/conn.go:254 +0x36b
created by github.com/sourcegraph/jsonrpc2.NewConn in goroutine 48
	/home/runner/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.2/conn.go:69 +0x23a
FAIL	github.com/icinga/icinga-notifications/internal/incident	4.113s
```